### PR TITLE
Fix e2e tests by using a different entities loading mechanism

### DIFF
--- a/server/src/database/db-config.service.ts
+++ b/server/src/database/db-config.service.ts
@@ -19,10 +19,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       username: this.configService.getOrThrow('db_user'),
       password: this.configService.getOrThrow('db_pw'),
       database: this.configService.getOrThrow('db_db'),
-      entities: [
-        join(__dirname, '**', '*.orm.{ts,js}'),
-        join(__dirname, '**', '*.entity.{ts,js}'),
-      ],
+      autoLoadEntities: true,
       migrationsTableName: 'migrations',
       migrationsRun: true,
       migrations: [join(__dirname, '**', '/migrations/*.{ts,js}')],


### PR DESCRIPTION
At the moment, e2e tests fail because of errors like this:

```
ERROR [ExceptionsHandler] No metadata for "ServiceDocOrm" was found.
```

This PR uses a different mechanism for loading entities in order to (temporarily) fix this. Unfortunately, I don't know enough about NestJS so I cannot say if the mechanism has any singificant downsides. According to the documentation on https://docs.nestjs.com/techniques/database, it has the following problem:

```
Note that entities that aren't registered through the forFeature() method, but are only referenced from the entity (via a relationship), won't be included by way of the autoLoadEntities setting. 
```

I simply don't know if that is something we care about at the moment. So my suggestion is that we:
1. use the new loading mechanism for now, so that we aren't blocked
2. look for the actual reason why tests failed
3. remove the new loading mechanism and properly fix the tests