### PR TITLE
Introduce tags to service-doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Example:
 ```json
 {
   "name": "PipelineService",
+  "tags": ["pipeline"],
   "providedAPIs": ["PipelineAPI"],
   "consumedAPIs": ["DatasourceAPI"],
   "repository": "https://github.com/jvalue/ods",

--- a/docs/msadoc.md
+++ b/docs/msadoc.md
@@ -18,6 +18,21 @@ The name of the microservice. The `name` is used as key to identify and referenc
 * Don't use spaces - otherwise API requests filtering by name might not work.
 
 
+### `tags` (string[])
+
+A list of tags for the microservice. The `tag` is used as key to filter services.
+#### Example
+```json
+{
+    "name": "PipelineService",
+    "tags": ["pipeline", "backend"],
+}
+```
+#### Best Practices
+* Use a consistent tagging scheme across all microservices.
+* Don't use spaces - otherwise API requests filtering by name might not work.
+
+
 ### `repository` (string)
 
 The link to the microservice's repository.

--- a/server/src/database/migrations.config.ts
+++ b/server/src/database/migrations.config.ts
@@ -19,9 +19,9 @@ export default new DataSource({
   password: configService.getOrThrow('msadoc_db_pw'),
   database: configService.getOrThrow('msadoc_db_db'),
   entities: [
-    join(__dirname, '**', '*.orm.{ts,js}'),
-    join(__dirname, '**', '*.entity.{ts,js}'),
+    join('src', '**', '*.orm.{ts,js}'),
+    join('src', '**', '*.entity.{ts,js}'),
   ],
-  migrations: [join(__dirname, '**', '/migrations/*.{ts,js}')],
+  migrations: [join('src', 'migrations', '*.{ts,js}')],
   migrationsTableName: 'migrations',
 });

--- a/server/src/database/migrations/1662991669104-ServiceDocsTags.ts
+++ b/server/src/database/migrations/1662991669104-ServiceDocsTags.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ServiceDocsTags1662991669104 implements MigrationInterface {
+  name = 'ServiceDocsTags1662991669104';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "ServiceDocs" ADD "tags" text array`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "ServiceDocs" DROP COLUMN "tags"`);
+  }
+}

--- a/server/src/database/migrations/1662991810846-ServiceDocsRenameProvidedAPIs.ts
+++ b/server/src/database/migrations/1662991810846-ServiceDocsRenameProvidedAPIs.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ServiceDocsRenameProvidedAPIs1662991810846
+  implements MigrationInterface
+{
+  name = 'ServiceDocsRenameProvidedAPIs1662991810846';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ServiceDocs" RENAME COLUMN "producedAPIs" TO "providedAPIs"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ServiceDocs" RENAME COLUMN "providedAPIs" TO "producedAPIs"`,
+    );
+  }
+}

--- a/server/src/service-docs/service-doc.dto.ts
+++ b/server/src/service-docs/service-doc.dto.ts
@@ -5,6 +5,17 @@ export class CreateServiceDocRequest {
   name: string;
 
   @ApiProperty()
+  tags?: string[];
+
+  @ApiProperty()
+  repository?: string;
+
+  @ApiProperty()
+  taskBoard?: string;
+
+  /** Dependencies */
+
+  @ApiProperty()
   consumedAPIs?: string[];
 
   @ApiProperty()
@@ -16,11 +27,7 @@ export class CreateServiceDocRequest {
   @ApiProperty()
   consumedEvents?: string[];
 
-  @ApiProperty()
-  repository?: string;
-
-  @ApiProperty()
-  taskBoard?: string;
+  /** Documentation links */
 
   @ApiProperty()
   developmentDocumentation?: string;
@@ -30,6 +37,8 @@ export class CreateServiceDocRequest {
 
   @ApiProperty()
   apiDocumentation?: string;
+
+  /** Responsibilities */
 
   @ApiProperty()
   responsibleTeam?: string;

--- a/server/src/service-docs/service-doc.orm.ts
+++ b/server/src/service-docs/service-doc.orm.ts
@@ -14,10 +14,21 @@ export class ServiceDocOrm {
   name: string;
 
   @Column('text', { array: true, nullable: true })
+  tags?: string[];
+
+  @Column({ nullable: true })
+  repository?: string;
+
+  @Column({ nullable: true })
+  taskBoard?: string;
+
+  /** Dependencies */
+
+  @Column('text', { array: true, nullable: true })
   consumedAPIs?: string[];
 
   @Column('text', { array: true, nullable: true })
-  producedAPIs?: string[];
+  providedAPIs?: string[];
 
   @Column('text', { array: true, nullable: true })
   producedEvents?: string[];
@@ -25,11 +36,7 @@ export class ServiceDocOrm {
   @Column('text', { array: true, nullable: true })
   consumedEvents?: string[];
 
-  @Column({ nullable: true })
-  repository?: string;
-
-  @Column({ nullable: true })
-  taskBoard?: string;
+  /** Documentation links */
 
   @Column({ nullable: true })
   developmentDocumentation?: string;
@@ -40,11 +47,15 @@ export class ServiceDocOrm {
   @Column({ nullable: true })
   apiDocumentation?: string;
 
+  /** Responsibilities */
+
   @Column({ nullable: true })
   responsibleTeam?: string;
 
   @Column('text', { array: true, nullable: true })
   responsibles?: string[];
+
+  /** Timestamps */
 
   @CreateDateColumn()
   creationTimestamp: Date;

--- a/server/src/service-docs/service-doc.orm.ts
+++ b/server/src/service-docs/service-doc.orm.ts
@@ -14,46 +14,46 @@ export class ServiceDocOrm {
   name: string;
 
   @Column('text', { array: true, nullable: true })
-  tags?: string[];
+  tags: string[] | null;
 
-  @Column({ nullable: true })
-  repository?: string;
+  @Column('character varying', { nullable: true })
+  repository: string | null;
 
-  @Column({ nullable: true })
-  taskBoard?: string;
+  @Column('character varying', { nullable: true })
+  taskBoard: string | null;
 
   /** Dependencies */
 
   @Column('text', { array: true, nullable: true })
-  consumedAPIs?: string[];
+  consumedAPIs: string[] | null;
 
   @Column('text', { array: true, nullable: true })
-  providedAPIs?: string[];
+  providedAPIs: string[] | null;
 
   @Column('text', { array: true, nullable: true })
-  producedEvents?: string[];
+  producedEvents: string[] | null;
 
   @Column('text', { array: true, nullable: true })
-  consumedEvents?: string[];
+  consumedEvents: string[] | null;
 
   /** Documentation links */
 
-  @Column({ nullable: true })
-  developmentDocumentation?: string;
+  @Column('character varying', { nullable: true })
+  developmentDocumentation: string | null;
 
-  @Column({ nullable: true })
-  deploymentDocumentation?: string;
+  @Column('character varying', { nullable: true })
+  deploymentDocumentation: string | null;
 
-  @Column({ nullable: true })
-  apiDocumentation?: string;
+  @Column('character varying', { nullable: true })
+  apiDocumentation: string | null;
 
   /** Responsibilities */
 
-  @Column({ nullable: true })
-  responsibleTeam?: string;
+  @Column('character varying', { nullable: true })
+  responsibleTeam: string | null;
 
   @Column('text', { array: true, nullable: true })
-  responsibles?: string[];
+  responsibles: string[] | null;
 
   /** Timestamps */
 

--- a/server/src/service-docs/service-docs.service.spec.ts
+++ b/server/src/service-docs/service-docs.service.spec.ts
@@ -11,9 +11,27 @@ describe('ServiceDocsService', () => {
 
   const mockedServiceDoc: ServiceDocOrm = {
     name: 'MyTestService',
+    tags: null,
+    repository: null,
+    taskBoard: null,
+    consumedAPIs: null,
+    consumedEvents: null,
+    producedEvents: null,
+    providedAPIs: null,
+    apiDocumentation: null,
+    deploymentDocumentation: null,
+    developmentDocumentation: null,
+    responsibles: null,
+    responsibleTeam: null,
     creationTimestamp: new Date(Date.now()),
     updateTimestamp: new Date(Date.now()),
   };
+  const expectedServiceDoc: ServiceDocModel = {
+    name: mockedServiceDoc.name,
+    creationTimestamp: mockedServiceDoc.creationTimestamp,
+    updateTimestamp: mockedServiceDoc.updateTimestamp,
+  };
+
   const exampleServiceDoc: ServiceDocModel = {
     name: mockedServiceDoc.name,
     creationTimestamp: new Date(Date.now()),
@@ -46,7 +64,7 @@ describe('ServiceDocsService', () => {
     const serviceDoc = await service.create(exampleServiceDoc);
 
     expect(repositoryMock.save).toHaveBeenCalledTimes(1);
-    expect(serviceDoc).toEqual(mockedServiceDoc);
+    expect(serviceDoc).toEqual(expectedServiceDoc);
   });
 
   it('should delete service-doc', async () => {
@@ -59,7 +77,7 @@ describe('ServiceDocsService', () => {
     expect(repositoryMock.delete).toHaveBeenCalledWith({
       name: mockedServiceDoc.name,
     });
-    expect(deleted).toEqual(mockedServiceDoc);
+    expect(deleted).toEqual(expectedServiceDoc);
   });
 
   it('should list service-doc', async () => {
@@ -68,7 +86,7 @@ describe('ServiceDocsService', () => {
     const allServiceDocs = await service.getAll();
 
     expect(repositoryMock.find).toHaveBeenCalledTimes(1);
-    expect(allServiceDocs).toContainEqual(mockedServiceDoc);
+    expect(allServiceDocs).toContainEqual(expectedServiceDoc);
   });
 
   it('should get service-doc', async () => {
@@ -80,6 +98,6 @@ describe('ServiceDocsService', () => {
     expect(repositoryMock.findBy).toHaveBeenCalledWith({
       name: mockedServiceDoc.name,
     });
-    expect(found).toEqual(mockedServiceDoc);
+    expect(found).toEqual(expectedServiceDoc);
   });
 });

--- a/server/src/service-docs/service-docs.service.ts
+++ b/server/src/service-docs/service-docs.service.ts
@@ -8,8 +8,9 @@ function fromOrm(entity: ServiceDocOrm): ServiceDocModel {
   // currently models are the same
   return {
     name: entity.name,
+    tags: entity.tags ?? undefined,
     consumedAPIs: entity.consumedAPIs ?? undefined,
-    providedAPIs: entity.producedAPIs ?? undefined,
+    providedAPIs: entity.providedAPIs ?? undefined,
     consumedEvents: entity.consumedEvents ?? undefined,
     producedEvents: entity.producedEvents ?? undefined,
     developmentDocumentation: entity.deploymentDocumentation ?? undefined,
@@ -29,6 +30,7 @@ function toOrm(
 ): ServiceDocModelWithoutTimestamps {
   return {
     name: model.name,
+    tags: model.tags,
     consumedAPIs: model.consumedAPIs,
     providedAPIs: model.providedAPIs,
     consumedEvents: model.consumedEvents,

--- a/server/src/service-docs/service-docs.service.ts
+++ b/server/src/service-docs/service-docs.service.ts
@@ -9,15 +9,15 @@ function fromOrm(entity: ServiceDocOrm): ServiceDocModel {
   return {
     name: entity.name,
     tags: entity.tags ?? undefined,
+    repository: entity.repository ?? undefined,
+    taskBoard: entity.taskBoard ?? undefined,
     consumedAPIs: entity.consumedAPIs ?? undefined,
     providedAPIs: entity.providedAPIs ?? undefined,
     consumedEvents: entity.consumedEvents ?? undefined,
     producedEvents: entity.producedEvents ?? undefined,
-    developmentDocumentation: entity.deploymentDocumentation ?? undefined,
+    developmentDocumentation: entity.developmentDocumentation ?? undefined,
     deploymentDocumentation: entity.deploymentDocumentation ?? undefined,
     apiDocumentation: entity.apiDocumentation ?? undefined,
-    repository: entity.repository ?? undefined,
-    taskBoard: entity.repository ?? undefined,
     responsibles: entity.responsibles ?? undefined,
     responsibleTeam: entity.responsibleTeam ?? undefined,
     creationTimestamp: entity.creationTimestamp ?? undefined,
@@ -27,21 +27,21 @@ function fromOrm(entity: ServiceDocOrm): ServiceDocModel {
 
 function toOrm(
   model: ServiceDocModelWithoutTimestamps,
-): ServiceDocModelWithoutTimestamps {
+): Omit<ServiceDocOrm, 'creationTimestamp' | 'updateTimestamp'> {
   return {
     name: model.name,
-    tags: model.tags,
-    consumedAPIs: model.consumedAPIs,
-    providedAPIs: model.providedAPIs,
-    consumedEvents: model.consumedEvents,
-    producedEvents: model.producedEvents,
-    developmentDocumentation: model.developmentDocumentation,
-    deploymentDocumentation: model.deploymentDocumentation,
-    apiDocumentation: model.apiDocumentation,
-    repository: model.repository,
-    taskBoard: model.taskBoard,
-    responsibles: model.responsibles,
-    responsibleTeam: model.responsibleTeam,
+    tags: model.tags ?? null,
+    repository: model.repository ?? null,
+    taskBoard: model.taskBoard ?? null,
+    consumedAPIs: model.consumedAPIs ?? null,
+    providedAPIs: model.providedAPIs ?? null,
+    consumedEvents: model.consumedEvents ?? null,
+    producedEvents: model.producedEvents ?? null,
+    developmentDocumentation: model.developmentDocumentation ?? null,
+    deploymentDocumentation: model.deploymentDocumentation ?? null,
+    apiDocumentation: model.apiDocumentation ?? null,
+    responsibles: model.responsibles ?? null,
+    responsibleTeam: model.responsibleTeam ?? null,
   };
 }
 
@@ -78,7 +78,7 @@ export class ServiceDocsService {
         `Could not find ServiceDoc with name "${serviceName}"`,
       );
     }
-    return results[0];
+    return fromOrm(results[0]);
   }
 
   async delete(serviceName: string): Promise<ServiceDocModel> {

--- a/server/test/service-docs.e2e-spec.ts
+++ b/server/test/service-docs.e2e-spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../src/app.module';
+import { CreateServiceDocRequest } from '../src/service-docs/service-doc.dto';
 
 describe('ServiceDocsController (e2e)', () => {
   let app: INestApplication;
@@ -65,7 +66,7 @@ describe('ServiceDocsController (e2e)', () => {
         .expect(201);
     });
 
-    it('should create service-doc', async () => {
+    it('should create simple service-doc', async () => {
       const accessToken = await getAccessToken();
       const creationResponse = await request(app.getHttpServer())
         .post('/service-docs')
@@ -75,6 +76,55 @@ describe('ServiceDocsController (e2e)', () => {
         })
         .expect(201);
       expect(creationResponse.body.name).toBeDefined();
+      expect(creationResponse.body.creationTimestamp).toBeDefined();
+      expect(creationResponse.body.updateTimestamp).toBeDefined();
+    });
+
+    it('should create complex service-doc', async () => {
+      const accessToken = await getAccessToken();
+      const dto: CreateServiceDocRequest = {
+        name: 'test-service',
+        tags: ['t', 'es'],
+        repository: 'repo',
+        taskBoard: 'tasks',
+        providedAPIs: ['API1', 'API2'],
+        producedEvents: ['event1', 'event2'],
+        consumedAPIs: ['API3', 'API4'],
+        consumedEvents: ['event3', 'event4'],
+        apiDocumentation: 'api',
+        deploymentDocumentation: 'deploy',
+        developmentDocumentation: 'develop',
+        responsibles: ['r1', 'r2'],
+        responsibleTeam: 'team',
+      };
+
+      const creationResponse = await request(app.getHttpServer())
+        .post('/service-docs')
+        .auth(accessToken, { type: 'bearer' })
+        .send(dto)
+        .expect(201);
+
+      expect(creationResponse.body.name).toEqual(dto.name);
+      expect(creationResponse.body.tags).toEqual(dto.tags);
+      expect(creationResponse.body.repository).toEqual(dto.repository);
+      expect(creationResponse.body.taskBoard).toEqual(dto.taskBoard);
+      expect(creationResponse.body.providedAPIs).toEqual(dto.providedAPIs);
+      expect(creationResponse.body.producedEvents).toEqual(dto.producedEvents);
+      expect(creationResponse.body.consumedAPIs).toEqual(dto.consumedAPIs);
+      expect(creationResponse.body.consumedEvents).toEqual(dto.consumedEvents);
+      expect(creationResponse.body.apiDocumentation).toEqual(
+        dto.apiDocumentation,
+      );
+      expect(creationResponse.body.deploymentDocumentation).toEqual(
+        dto.deploymentDocumentation,
+      );
+      expect(creationResponse.body.developmentDocumentation).toEqual(
+        dto.developmentDocumentation,
+      );
+      expect(creationResponse.body.responsibles).toEqual(dto.responsibles);
+      expect(creationResponse.body.responsibleTeam).toEqual(
+        dto.responsibleTeam,
+      );
       expect(creationResponse.body.creationTimestamp).toBeDefined();
       expect(creationResponse.body.updateTimestamp).toBeDefined();
     });


### PR DESCRIPTION
* Add array field `tags` for tagging a service-doc. Will be later used in UI to filter.
* Fix migrations path to generate migrations via typeorm.
* Fix fields `providedAPIs`, `taskBoard` and `developmentDocumentation` which were handled incorrectly in persistance.