### PR TITLE
Add routing and Material UI

### DIFF
--- a/frontend/.vscode/snippets.code-snippets
+++ b/frontend/.vscode/snippets.code-snippets
@@ -1,0 +1,34 @@
+{
+  // See https://code.visualstudio.com/docs/editor/userdefinedsnippets
+
+  "reactcomponent": {
+    "scope": "typescriptreact",
+    "prefix": "reactcomponent",
+    "body": [
+      "import React from 'react';",
+      "",
+      "interface Props {",
+      "",
+      "}",
+      "export const $1: React.FC<Props> = props => {",
+      "  const controller = useController(props);",
+      "",
+      "  return <React.Fragment></React.Fragment>",
+      "}",
+      "",
+      "interface State {",
+      "",
+      "}",
+      "interface Controller {",
+      "  state: State;",
+      "}",
+      "function useController(props: Props): Controller {",
+      "  const [state, setState] = React.useState<State>({});",
+      "",
+      "  return {",
+      "    state: state,",
+      "  }",
+      "}"
+    ]
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,12 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@emotion/react": "^11.10.4",
+        "@emotion/styled": "^11.10.4",
+        "@fontsource/roboto": "^4.5.8",
+        "@mui/icons-material": "^5.10.6",
+        "@mui/lab": "^5.0.0-alpha.100",
+        "@mui/material": "^5.10.6",
         "msadoc-client": "file:../client-generated",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -24,6 +30,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.7.1",
+        "sass": "^1.54.9",
         "typescript": "^4.8.3"
       }
     },
@@ -2171,6 +2178,170 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.10.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
+      "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.17.12",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.0",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.0.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.10.3",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
+      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.0.13"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.10.4",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.4.tgz",
+      "integrity": "sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/cache": "^11.10.0",
+        "@emotion/serialize": "^1.1.0",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
+      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.10.4",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.4.tgz",
+      "integrity": "sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@emotion/serialize": "^1.1.0",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
@@ -2233,6 +2404,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -3011,6 +3187,307 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-alpha.98",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.98.tgz",
+      "integrity": "sha512-c0U51+K2m57MASpRrmNs6qTXSvktDbVcSjD8zCRPbfuwYWERGGwNxwM3/jsBa4dSojTSmLPnOBFDypl74Ds6yQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.6",
+        "@popperjs/core": "^2.11.6",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/base/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.6.tgz",
+      "integrity": "sha512-dmyQBqrKmVU6yCSM4GGal5qNXpViXX+/V1t0GA1A5i9QF5Gx6noV/cw0hrSS2ffLT8L2oScq1oTdA6NVIiQ8lg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.6.tgz",
+      "integrity": "sha512-QwxdRmLA46S94B0hExPDx0td+A2unF+33bQ6Cs+lNpJKVsm1YeHwNdYXYcnpWeHeQQ07055OXl7IB2GKDd0MfA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab": {
+      "version": "5.0.0-alpha.100",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.100.tgz",
+      "integrity": "sha512-jG2burEfzvr3BnvMrKs2eizgqq/p4tZkAetUdr9SEpxOIi0J5RBtFkqIz8KR8Tl3HaTnCAqotaI4UcwlVej9rA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/base": "5.0.0-alpha.98",
+        "@mui/system": "^5.10.6",
+        "@mui/utils": "^5.10.6",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/material": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.6.tgz",
+      "integrity": "sha512-QilW5PAAGSQdN7Cpp4rwSQ1doJAt3ca1a2PHZtr8RLVlpHnXb+qQ8CeDo9+9V2fK5CDNdtTN1F+iJKO43aFBpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/base": "5.0.0-alpha.98",
+        "@mui/core-downloads-tracker": "^5.10.6",
+        "@mui/system": "^5.10.6",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.6",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.10.6.tgz",
+      "integrity": "sha512-I/W0QyTLRdEx6py3lKAquKO/rNF/7j+nIOM/xCyI9kU0fcotVTcTY08mKMsS6vrzdWpi6pAkD0wP0KwWy5R5VA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/utils": "^5.10.6",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.6.tgz",
+      "integrity": "sha512-OnVw5xnO4l0XzlJFhKif/RlLenBNhyEQQlSTwB9ApSWB05UAU5ZSbjNsRfyEKvgmQ/fPa+MqPD/dzxbIRCwyeg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/cache": "^11.10.3",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.6.tgz",
+      "integrity": "sha512-HfQVX7e2xpQ3jtdB/WwtkFVtozMOozyN575/63u8ILHkE8wGDhblmCieAsnyJPFbm7WBW5PCMyzmfr4QyKLaYg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/private-theming": "^5.10.6",
+        "@mui/styled-engine": "^5.10.6",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.6",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==",
+      "peerDependencies": {
+        "@types/react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.6.tgz",
+      "integrity": "sha512-g0Qs8xN/MW2M3fLL8197h5J2VB9U+49fLlnKKqC6zy/yus5cZwdT+Gwec+wUMxgwQoxMDn+J8oDWAn28kEOR/Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@types/prop-types": "^15.7.5",
+        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3090,6 +3567,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@remix-run/router": {
@@ -3624,8 +4110,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -3646,7 +4131,6 @@
       "version": "18.0.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.18.tgz",
       "integrity": "sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3658,6 +4142,22 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
       "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
       "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-is": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
+      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -3678,8 +4178,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -5193,6 +5692,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5853,8 +6360,7 @@
     "node_modules/csstype": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6097,6 +6603,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -7502,6 +8017,11 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -8091,6 +8611,19 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -8361,6 +8894,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "devOptional": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -13699,6 +14238,21 @@
         }
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -14137,6 +14691,23 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
+    },
+    "node_modules/sass": {
+      "version": "1.54.9",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.9.tgz",
+      "integrity": "sha512-xb1hjASzEH+0L0WI9oFjqhRi51t/gagWnxLiwUNMltA0Ab6jIDkAacgKiGYKM9Jhy109osM7woEEai6SXeJo5Q==",
+      "devOptional": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/sass-loader": {
       "version": "12.6.0",
@@ -14777,6 +15348,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -17782,6 +18358,133 @@
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
       "requires": {}
     },
+    "@emotion/babel-plugin": {
+      "version": "11.10.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
+      "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.17.12",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.0",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.0.13"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+        }
+      }
+    },
+    "@emotion/cache": {
+      "version": "11.10.3",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
+      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.0.13"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
+    "@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "@emotion/react": {
+      "version": "11.10.4",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.4.tgz",
+      "integrity": "sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/cache": "^11.10.0",
+        "@emotion/serialize": "^1.1.0",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "hoist-non-react-statics": "^3.3.1"
+      }
+    },
+    "@emotion/serialize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+      "requires": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
+      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+    },
+    "@emotion/styled": {
+      "version": "11.10.4",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.4.tgz",
+      "integrity": "sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@emotion/serialize": "^1.1.0",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0"
+      }
+    },
+    "@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+    },
+    "@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "requires": {}
+    },
+    "@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
+    },
     "@eslint/eslintrc": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
@@ -17825,6 +18528,11 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
+    },
+    "@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -18403,6 +19111,149 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "@mui/base": {
+      "version": "5.0.0-alpha.98",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.98.tgz",
+      "integrity": "sha512-c0U51+K2m57MASpRrmNs6qTXSvktDbVcSjD8zCRPbfuwYWERGGwNxwM3/jsBa4dSojTSmLPnOBFDypl74Ds6yQ==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.6",
+        "@popperjs/core": "^2.11.6",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
+    "@mui/core-downloads-tracker": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.6.tgz",
+      "integrity": "sha512-dmyQBqrKmVU6yCSM4GGal5qNXpViXX+/V1t0GA1A5i9QF5Gx6noV/cw0hrSS2ffLT8L2oScq1oTdA6NVIiQ8lg=="
+    },
+    "@mui/icons-material": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.6.tgz",
+      "integrity": "sha512-QwxdRmLA46S94B0hExPDx0td+A2unF+33bQ6Cs+lNpJKVsm1YeHwNdYXYcnpWeHeQQ07055OXl7IB2GKDd0MfA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0"
+      }
+    },
+    "@mui/lab": {
+      "version": "5.0.0-alpha.100",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.100.tgz",
+      "integrity": "sha512-jG2burEfzvr3BnvMrKs2eizgqq/p4tZkAetUdr9SEpxOIi0J5RBtFkqIz8KR8Tl3HaTnCAqotaI4UcwlVej9rA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/base": "5.0.0-alpha.98",
+        "@mui/system": "^5.10.6",
+        "@mui/utils": "^5.10.6",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
+    "@mui/material": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.6.tgz",
+      "integrity": "sha512-QilW5PAAGSQdN7Cpp4rwSQ1doJAt3ca1a2PHZtr8RLVlpHnXb+qQ8CeDo9+9V2fK5CDNdtTN1F+iJKO43aFBpQ==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/base": "5.0.0-alpha.98",
+        "@mui/core-downloads-tracker": "^5.10.6",
+        "@mui/system": "^5.10.6",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.6",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
+    "@mui/private-theming": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.10.6.tgz",
+      "integrity": "sha512-I/W0QyTLRdEx6py3lKAquKO/rNF/7j+nIOM/xCyI9kU0fcotVTcTY08mKMsS6vrzdWpi6pAkD0wP0KwWy5R5VA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/utils": "^5.10.6",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/styled-engine": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.6.tgz",
+      "integrity": "sha512-OnVw5xnO4l0XzlJFhKif/RlLenBNhyEQQlSTwB9ApSWB05UAU5ZSbjNsRfyEKvgmQ/fPa+MqPD/dzxbIRCwyeg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/cache": "^11.10.3",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/system": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.6.tgz",
+      "integrity": "sha512-HfQVX7e2xpQ3jtdB/WwtkFVtozMOozyN575/63u8ILHkE8wGDhblmCieAsnyJPFbm7WBW5PCMyzmfr4QyKLaYg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/private-theming": "^5.10.6",
+        "@mui/styled-engine": "^5.10.6",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.6",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==",
+      "requires": {}
+    },
+    "@mui/utils": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.6.tgz",
+      "integrity": "sha512-g0Qs8xN/MW2M3fLL8197h5J2VB9U+49fLlnKKqC6zy/yus5cZwdT+Gwec+wUMxgwQoxMDn+J8oDWAn28kEOR/Q==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@types/prop-types": "^15.7.5",
+        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -18441,6 +19292,11 @@
         "schema-utils": "^3.0.0",
         "source-map": "^0.7.3"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@remix-run/router": {
       "version": "1.0.0",
@@ -18841,8 +19697,7 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -18863,7 +19718,6 @@
       "version": "18.0.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.18.tgz",
       "integrity": "sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -18875,6 +19729,22 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
       "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
       "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-is": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
+      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "requires": {
         "@types/react": "*"
       }
@@ -18895,8 +19765,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -20016,6 +20885,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -20477,8 +21351,7 @@
     "csstype": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -20659,6 +21532,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -21691,6 +22573,11 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -22087,6 +22974,21 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -22286,6 +23188,12 @@
       "version": "9.0.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
       "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
+    },
+    "immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "devOptional": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -25960,6 +26868,17 @@
         "workbox-webpack-plugin": "^6.4.1"
       }
     },
+    "react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -26276,6 +27195,17 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
+    },
+    "sass": {
+      "version": "1.54.9",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.9.tgz",
+      "integrity": "sha512-xb1hjASzEH+0L0WI9oFjqhRi51t/gagWnxLiwUNMltA0Ab6jIDkAacgKiGYKM9Jhy109osM7woEEai6SXeJo5Q==",
+      "devOptional": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
     },
     "sass-loader": {
       "version": "12.6.0",
@@ -26756,6 +27686,11 @@
         "browserslist": "^4.16.6",
         "postcss-selector-parser": "^6.0.4"
       }
+    },
+    "stylis": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "msadoc-client": "file:../client-generated",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.4.0",
         "react-scripts": "5.0.1",
         "rxjs": "^7.5.6"
       },
@@ -33,6 +34,7 @@
         "rxjs": "^7.2.0"
       },
       "devDependencies": {
+        "rimraf": "^3.0.2",
         "typescript": "^4.0"
       }
     },
@@ -3088,6 +3090,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.0.tgz",
+      "integrity": "sha512-SCR1cxRSMNKjaVYptCzBApPDqGwa3FGdjVHc+rOToocNPHQdIYLZBfv/3f+KvYuXDkUGVIW9IAzmPNZDRL1I4A==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13588,6 +13598,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.0.tgz",
+      "integrity": "sha512-B+5bEXFlgR1XUdHYR6P94g299SjrfCBMmEDJNcFbpAyRH1j1748yt9NdDhW3++nw1lk3zQJ6aOO66zUx3KlTZg==",
+      "dependencies": {
+        "@remix-run/router": "1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.0.tgz",
+      "integrity": "sha512-4Aw1xmXKeleYYQ3x0Lcl2undHR6yMjXZjd9DKZd53SGOYqirrUThyUb0wwAX5VZAyvSuzjNJmZlJ3rR9+/vzqg==",
+      "dependencies": {
+        "react-router": "6.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -18402,6 +18441,11 @@
         "schema-utils": "^3.0.0",
         "source-map": "^0.7.3"
       }
+    },
+    "@remix-run/router": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.0.tgz",
+      "integrity": "sha512-SCR1cxRSMNKjaVYptCzBApPDqGwa3FGdjVHc+rOToocNPHQdIYLZBfv/3f+KvYuXDkUGVIW9IAzmPNZDRL1I4A=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -24415,6 +24459,7 @@
     "msadoc-client": {
       "version": "file:../client-generated",
       "requires": {
+        "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
         "typescript": "^4.0"
       }
@@ -25843,6 +25888,22 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.0.tgz",
+      "integrity": "sha512-B+5bEXFlgR1XUdHYR6P94g299SjrfCBMmEDJNcFbpAyRH1j1748yt9NdDhW3++nw1lk3zQJ6aOO66zUx3KlTZg==",
+      "requires": {
+        "@remix-run/router": "1.0.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.0.tgz",
+      "integrity": "sha512-4Aw1xmXKeleYYQ3x0Lcl2undHR6yMjXZjd9DKZd53SGOYqirrUThyUb0wwAX5VZAyvSuzjNJmZlJ3rR9+/vzqg==",
+      "requires": {
+        "react-router": "6.4.0"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "msadoc-client": "file:../client-generated",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.0",
     "react-scripts": "5.0.1",
     "rxjs": "^7.5.6"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,12 @@
     "compile-client-library": "npm install --prefix ../client-generated"
   },
   "dependencies": {
+    "@emotion/react": "^11.10.4",
+    "@emotion/styled": "^11.10.4",
+    "@fontsource/roboto": "^4.5.8",
+    "@mui/icons-material": "^5.10.6",
+    "@mui/lab": "^5.0.0-alpha.100",
+    "@mui/material": "^5.10.6",
     "msadoc-client": "file:../client-generated",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -26,6 +32,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
+    "sass": "^1.54.9",
     "typescript": "^4.8.3"
   }
 }

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,39 +1,18 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 
+import { AppRoutes } from './routes';
 import { AuthDataServiceContextProvider } from './services/auth-data-service';
-import {
-  HttpServiceContextProvider,
-  useHttpServiceContext,
-} from './services/http-service';
+import { HttpServiceContextProvider } from './services/http-service';
 
 export const App: React.FC = () => {
   return (
-    <AuthDataServiceContextProvider>
-      <HttpServiceContextProvider>
-        <Test />
-      </HttpServiceContextProvider>
-    </AuthDataServiceContextProvider>
+    <BrowserRouter>
+      <AuthDataServiceContextProvider>
+        <HttpServiceContextProvider>
+          <AppRoutes />
+        </HttpServiceContextProvider>
+      </AuthDataServiceContextProvider>
+    </BrowserRouter>
   );
-};
-
-// This is just a temporary component to showcase how the HTTP Service works.
-const Test: React.FC = () => {
-  const httpService = useHttpServiceContext();
-
-  React.useEffect(() => {
-    void (async (): Promise<void> => {
-      const loginResponse = await httpService.performLogin('myuser', '12345');
-      if (loginResponse.status !== 200) {
-        return;
-      }
-      const serviceDocsResponse = await httpService.listAllServiceDocs();
-      if (serviceDocsResponse.status !== 200) {
-        return;
-      }
-      console.log(serviceDocsResponse.data);
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return <div>msadoc</div>;
 };

--- a/frontend/src/components/login-page/index.tsx
+++ b/frontend/src/components/login-page/index.tsx
@@ -1,0 +1,1 @@
+export { LoginPage } from './login-page';

--- a/frontend/src/components/login-page/login-page.tsx
+++ b/frontend/src/components/login-page/login-page.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useHttpServiceContext } from '../../services/http-service';
+
+enum ViewState {
+  Default,
+  IsLoading,
+  WrongUsernameOrPassword,
+  UnknownError,
+}
+
+export const LoginPage: React.FC = () => {
+  const controller = useController();
+
+  return (
+    <React.Fragment>
+      <h3>Login Page</h3>
+
+      {controller.state.viewState === ViewState.IsLoading && (
+        <div>Loading...</div>
+      )}
+      {controller.state.viewState === ViewState.WrongUsernameOrPassword && (
+        <div>Wrong username or password</div>
+      )}
+      {controller.state.viewState === ViewState.UnknownError && (
+        <div>Unknown error, please try again</div>
+      )}
+
+      <input
+        type="text"
+        value={controller.state.username}
+        onChange={(e): void => controller.setUsername(e.target.value)}
+      />
+      <input
+        type="password"
+        value={controller.state.password}
+        onChange={(e): void => controller.setPassword(e.target.value)}
+      />
+
+      <button
+        type="button"
+        onClick={(): void => void controller.performLogin()}
+      >
+        Login
+      </button>
+    </React.Fragment>
+  );
+};
+
+interface State {
+  username: string;
+  password: string;
+
+  viewState: ViewState;
+}
+interface Controller {
+  state: State;
+
+  setUsername: (username: string) => void;
+  setPassword: (password: string) => void;
+
+  performLogin: () => Promise<void>;
+}
+function useController(): Controller {
+  const [state, setState] = React.useState<State>({
+    username: '',
+    password: '',
+    viewState: ViewState.Default,
+  });
+
+  const navigate = useNavigate();
+  const httpService = useHttpServiceContext();
+
+  return {
+    state: state,
+
+    setUsername: (username): void => {
+      setState((state) => ({ ...state, username: username }));
+    },
+    setPassword: (password): void => {
+      setState((state) => ({ ...state, password: password }));
+    },
+    performLogin: async (): Promise<void> => {
+      setState((state) => ({ ...state, viewState: ViewState.IsLoading }));
+      const loginResponse = await httpService.performLogin(
+        state.username,
+        state.password,
+      );
+
+      if (loginResponse.status === 200) {
+        navigate('/main');
+        return;
+      }
+      if (loginResponse.status === 401) {
+        setState((state) => ({
+          ...state,
+          viewState: ViewState.WrongUsernameOrPassword,
+        }));
+        return;
+      }
+      setState((state) => ({ ...state, viewState: ViewState.UnknownError }));
+    },
+  };
+}

--- a/frontend/src/components/login-page/login-page.tsx
+++ b/frontend/src/components/login-page/login-page.tsx
@@ -1,3 +1,6 @@
+import { LoadingButton } from '@mui/lab';
+import { Box, Stack, TextField, Typography } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -15,35 +18,125 @@ export const LoginPage: React.FC = () => {
 
   return (
     <React.Fragment>
-      <h3>Login Page</h3>
+      <Grid sx={{ height: '100%' }} container>
+        <Grid
+          xs={4}
+          sx={{
+            background: (theme) => theme.palette.primary.dark,
+            padding: 2,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <Box>
+            <Box sx={{ position: 'relative' }}>
+              <Typography
+                variant="h3"
+                sx={{
+                  color: '#ffffff',
+                  fontWeight: 700,
+                  letterSpacing: '0.15em',
+                  marginLeft: '1.5rem',
+                }}
+              >
+                msadoc
+              </Typography>
 
-      {controller.state.viewState === ViewState.IsLoading && (
-        <div>Loading...</div>
-      )}
-      {controller.state.viewState === ViewState.WrongUsernameOrPassword && (
-        <div>Wrong username or password</div>
-      )}
-      {controller.state.viewState === ViewState.UnknownError && (
-        <div>Unknown error, please try again</div>
-      )}
+              {/* A semi-transparent highlight element. */}
+              <Box
+                sx={{
+                  position: 'absolute',
+                  bottom: 0,
+                  left: 0,
+                  display: 'block',
+                  width: '8rem',
+                  height: '1.3rem',
+                  background: 'rgba(255,255,255,0.2)',
+                  pointerEvents: 'none',
+                }}
+              />
+            </Box>
 
-      <input
-        type="text"
-        value={controller.state.username}
-        onChange={(e): void => controller.setUsername(e.target.value)}
-      />
-      <input
-        type="password"
-        value={controller.state.password}
-        onChange={(e): void => controller.setPassword(e.target.value)}
-      />
+            <Box>
+              <Typography
+                variant="h5"
+                sx={{
+                  color: '#ffffff',
+                  fontWeight: 300,
+                  letterSpacing: '0.1em',
+                  marginTop: '1rem',
+                  marginLeft: '1.5rem',
+                }}
+              >
+                Recentralize decentralized documentation!
+              </Typography>
+            </Box>
+          </Box>
+        </Grid>
 
-      <button
-        type="button"
-        onClick={(): void => void controller.performLogin()}
-      >
-        Login
-      </button>
+        <Grid
+          xs={8}
+          sx={{
+            padding: 4,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Box sx={{ width: '100%', maxWidth: '500px' }}>
+            <form
+              onSubmit={(e): void => {
+                e.preventDefault();
+                void controller.performLogin();
+              }}
+            >
+              <Stack spacing={2}>
+                <Typography variant="h4">Login</Typography>
+
+                {controller.state.viewState ===
+                  ViewState.WrongUsernameOrPassword && (
+                  <Box
+                    sx={{
+                      color: (theme) => theme.palette.error.main,
+                    }}
+                  >
+                    Wrong username or password
+                  </Box>
+                )}
+                {controller.state.viewState === ViewState.UnknownError && (
+                  <Box
+                    sx={{
+                      color: (theme) => theme.palette.error.main,
+                    }}
+                  >
+                    Unknown error, please try again
+                  </Box>
+                )}
+
+                <TextField
+                  label="Username"
+                  value={controller.state.username}
+                  onChange={(e): void => controller.setUsername(e.target.value)}
+                />
+                <TextField
+                  type="password"
+                  label="Password"
+                  value={controller.state.password}
+                  onChange={(e): void => controller.setPassword(e.target.value)}
+                />
+
+                <LoadingButton
+                  variant="contained"
+                  loading={controller.state.viewState === ViewState.IsLoading}
+                  type="submit"
+                >
+                  Login
+                </LoadingButton>
+              </Stack>
+            </form>
+          </Box>
+        </Grid>
+      </Grid>
     </React.Fragment>
   );
 };

--- a/frontend/src/components/main-page/auth-tokens-page/auth-tokens-page.tsx
+++ b/frontend/src/components/main-page/auth-tokens-page/auth-tokens-page.tsx
@@ -1,0 +1,10 @@
+import { Box } from '@mui/material';
+import React from 'react';
+
+export const AuthTokensPage: React.FC = () => {
+  return (
+    <Box sx={{ height: '100%', overflowY: 'auto' }}>
+      <h3>Auth Tokens</h3>
+    </Box>
+  );
+};

--- a/frontend/src/components/main-page/auth-tokens-page/index.tsx
+++ b/frontend/src/components/main-page/auth-tokens-page/index.tsx
@@ -1,0 +1,1 @@
+export { AuthTokensPage } from './auth-tokens-page';

--- a/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mui/material';
 import React from 'react';
 
 import { ListAllServiceDocs200ResponseData } from '../../../models/api';
@@ -6,7 +7,11 @@ import { useServiceDocsServiceContext } from '../services/service-docs-service';
 export const GroupsTreePage: React.FC = () => {
   const controller = useController();
 
-  return <span>{JSON.stringify(controller.serviceDocs)}</span>;
+  return (
+    <Box sx={{ height: '100%', overflowX: 'hidden', overflowY: 'auto' }}>
+      {JSON.stringify(controller.serviceDocs)}
+    </Box>
+  );
 };
 
 interface Controller {

--- a/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { ListAllServiceDocs200ResponseData } from '../../../models/api';
+import { useServiceDocsServiceContext } from '../services/service-docs-service';
+
+export const GroupsTreePage: React.FC = () => {
+  const controller = useController();
+
+  return <span>{JSON.stringify(controller.serviceDocs)}</span>;
+};
+
+interface Controller {
+  serviceDocs: ListAllServiceDocs200ResponseData;
+}
+function useController(): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  return {
+    serviceDocs: serviceDocsService.serviceDocs,
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/index.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/index.tsx
@@ -1,0 +1,1 @@
+export { GroupsTreePage as ServiceDocsPage } from './groups-tree-page';

--- a/frontend/src/components/main-page/index.tsx
+++ b/frontend/src/components/main-page/index.tsx
@@ -1,0 +1,1 @@
+export { MainPage } from './main-page';

--- a/frontend/src/components/main-page/left-menu.tsx
+++ b/frontend/src/components/main-page/left-menu.tsx
@@ -1,0 +1,131 @@
+import { AccountTree, Key, Logout, Refresh } from '@mui/icons-material';
+import { Box, IconButton, Stack, Tooltip } from '@mui/material';
+import React from 'react';
+import { useMatch, useNavigate, useResolvedPath } from 'react-router-dom';
+
+import { useAuthDataServiceContext } from '../../services/auth-data-service';
+
+interface Props {
+  reloadServiceDocs: () => void;
+}
+export const LeftMenu: React.FC<Props> = (props) => {
+  const controller = useController();
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        height: '100%',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        background: (theme) => theme.palette.primary.dark,
+      }}
+    >
+      <Stack sx={{ width: '100%' }}>
+        <NavButtonWithRouterTarget
+          routerTarget="/main/groups-tree"
+          tooltipText="Groups Tree"
+        >
+          <AccountTree fontSize="inherit" />
+        </NavButtonWithRouterTarget>
+
+        <NavButtonWithRouterTarget
+          routerTarget="/main/auth-tokens"
+          tooltipText="Auth Tokens"
+        >
+          <Key fontSize="inherit" />
+        </NavButtonWithRouterTarget>
+      </Stack>
+
+      <Box>
+        <Stack sx={{ width: '100%' }}>
+          <NavButton
+            tooltipText="Reload Service Docs"
+            onClick={(): void => props.reloadServiceDocs()}
+          >
+            <Refresh fontSize="inherit" />
+          </NavButton>
+
+          <NavButton
+            tooltipText="Logout"
+            onClick={(): void => controller.performLogout()}
+          >
+            <Logout fontSize="inherit" />
+          </NavButton>
+        </Stack>
+      </Box>
+    </Box>
+  );
+};
+
+interface Controller {
+  performLogout: () => void;
+}
+function useController(): Controller {
+  const navigate = useNavigate();
+  const authDataService = useAuthDataServiceContext();
+
+  return {
+    performLogout: (): void => {
+      authDataService.deleteAccessAndRefreshToken();
+      navigate('/');
+    },
+  };
+}
+
+interface NavButtonProps {
+  tooltipText: string;
+  children: React.ReactNode;
+  highlight?: boolean;
+  onClick?: () => void;
+}
+const NavButton: React.FC<NavButtonProps> = (props) => {
+  return (
+    <Tooltip title={props.tooltipText} placement="right">
+      <IconButton
+        size="large"
+        sx={{
+          width: '100%',
+          height: '70px',
+          borderRadius: 0,
+          color: props.highlight === true ? '#ffffff' : 'rgba(255,255,255,0.5)',
+          background:
+            props.highlight === true ? 'rgba(255,255,255,0.2)' : 'none',
+          '&:hover': {
+            color:
+              props.highlight === true ? '#ffffff' : 'rgba(255,255,255,0.8)',
+            background:
+              props.highlight === true ? 'rgba(255,255,255,0.2)' : 'none',
+          },
+        }}
+        onClick={(): void => props.onClick?.()}
+      >
+        {props.children}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+interface NavButtonWithRouterTragetProps
+  extends Omit<NavButtonProps, 'highlight' | 'onClick'> {
+  routerTarget: string;
+}
+const NavButtonWithRouterTarget: React.FC<NavButtonWithRouterTragetProps> = (
+  props,
+) => {
+  const navigate = useNavigate();
+
+  // This is similar to the example on https://github.com/remix-run/react-router/blob/8b00e7a4ff4bd75f161c3f882b9508cb206063a6/examples/custom-link/src/App.tsx
+
+  const resolvedPath = useResolvedPath(props.routerTarget);
+  const isMatching =
+    useMatch({ path: resolvedPath.pathname, end: true }) != null;
+
+  return (
+    <NavButton
+      {...props}
+      highlight={isMatching}
+      onClick={(): void => navigate(props.routerTarget)}
+    />
+  );
+};

--- a/frontend/src/components/main-page/main-page.tsx
+++ b/frontend/src/components/main-page/main-page.tsx
@@ -1,8 +1,19 @@
+import {
+  Backdrop,
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
 import React from 'react';
 
 import { ListAllServiceDocs200ResponseData } from '../../models/api';
 import { useHttpServiceContext } from '../../services/http-service';
 
+import { LeftMenu } from './left-menu';
 import { MainPageRoutes } from './routes';
 import { ServiceDocsServiceContextProvider } from './services/service-docs-service';
 
@@ -11,17 +22,64 @@ export const MainPage: React.FC = () => {
 
   return (
     <React.Fragment>
-      {controller.state.isLoading && <span>Loading</span>}
-      {controller.state.error && <span>Error</span>}
-      {!controller.state.isLoading &&
-        !controller.state.error &&
-        controller.state.serviceDocs && (
-          <ServiceDocsServiceContextProvider
-            serviceDocs={controller.state.serviceDocs}
-          >
-            <MainPageRoutes />
-          </ServiceDocsServiceContextProvider>
-        )}
+      <Box
+        sx={{
+          display: 'flex',
+          height: '100%',
+        }}
+      >
+        <Box
+          sx={{
+            width: '70px',
+            flexShrink: 0,
+          }}
+        >
+          <LeftMenu
+            reloadServiceDocs={(): void => void controller.loadServiceDocs()}
+          />
+        </Box>
+
+        <Box sx={{ flexGrow: 1, overflow: 'hidden', position: 'relative' }}>
+          {controller.state.isLoading && (
+            <Backdrop sx={{ color: '#ffffff', position: 'absolute' }} open>
+              <CircularProgress color="inherit" />
+            </Backdrop>
+          )}
+          {controller.state.error && (
+            <Backdrop sx={{ color: '#ffffff', position: 'absolute' }} open>
+              <Card variant="outlined">
+                <CardContent>
+                  <Typography variant="h5">Error</Typography>
+
+                  <Typography>
+                    An error has occurred while loading the Service Docs.
+                  </Typography>
+                </CardContent>
+
+                <CardActions>
+                  <Button
+                    onClick={(): void => void controller.loadServiceDocs()}
+                  >
+                    Try again
+                  </Button>
+                </CardActions>
+              </Card>
+            </Backdrop>
+          )}
+
+          {/* 
+            When loading new Service Docs, we keep the following components as-is in order not to lose the component-internal state. 
+            Otherwise, whenever the Service Docs are reloaded, the user would potentially have to redo all of the commands that lead him/her to the current state. 
+          */}
+          {controller.state.serviceDocs && (
+            <ServiceDocsServiceContextProvider
+              serviceDocs={controller.state.serviceDocs}
+            >
+              <MainPageRoutes />
+            </ServiceDocsServiceContextProvider>
+          )}
+        </Box>
+      </Box>
     </React.Fragment>
   );
 };
@@ -33,6 +91,8 @@ interface State {
 }
 interface Controller {
   state: State;
+
+  loadServiceDocs: () => Promise<void>;
 }
 function useController(): Controller {
   const httpService = useHttpServiceContext();
@@ -67,5 +127,7 @@ function useController(): Controller {
 
   return {
     state: state,
+
+    loadServiceDocs: loadServiceDocs,
   };
 }

--- a/frontend/src/components/main-page/main-page.tsx
+++ b/frontend/src/components/main-page/main-page.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { ListAllServiceDocs200ResponseData } from '../../models/api';
+import { useHttpServiceContext } from '../../services/http-service';
+
+import { MainPageRoutes } from './routes';
+import { ServiceDocsServiceContextProvider } from './services/service-docs-service';
+
+export const MainPage: React.FC = () => {
+  const controller = useController();
+
+  return (
+    <React.Fragment>
+      {controller.state.isLoading && <span>Loading</span>}
+      {controller.state.error && <span>Error</span>}
+      {!controller.state.isLoading &&
+        !controller.state.error &&
+        controller.state.serviceDocs && (
+          <ServiceDocsServiceContextProvider
+            serviceDocs={controller.state.serviceDocs}
+          >
+            <MainPageRoutes />
+          </ServiceDocsServiceContextProvider>
+        )}
+    </React.Fragment>
+  );
+};
+
+interface State {
+  isLoading: boolean;
+  error: boolean;
+  serviceDocs: ListAllServiceDocs200ResponseData | undefined;
+}
+interface Controller {
+  state: State;
+}
+function useController(): Controller {
+  const httpService = useHttpServiceContext();
+
+  const [state, setState] = React.useState<State>({
+    isLoading: true,
+    error: false,
+    serviceDocs: undefined,
+  });
+
+  async function loadServiceDocs(): Promise<void> {
+    setState((state) => ({ ...state, isLoading: true, error: false }));
+    const serviceDocs = await httpService.listAllServiceDocs();
+    setState((state) => ({ ...state, isLoading: false }));
+
+    if (serviceDocs.status === 200) {
+      setState((state) => ({
+        ...state,
+        error: false,
+        serviceDocs: serviceDocs.data,
+      }));
+      return;
+    }
+
+    setState((state) => ({ ...state, error: true }));
+  }
+
+  React.useEffect(() => {
+    void loadServiceDocs();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    state: state,
+  };
+}

--- a/frontend/src/components/main-page/routes.tsx
+++ b/frontend/src/components/main-page/routes.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
+
+import { GroupsTreePage } from './groups-tree-page/groups-tree-page';
+
+export const MainPageRoutes: React.FC = () => {
+  const routes: RouteObject[] = [
+    {
+      path: '/',
+      element: <Navigate to="/main/groups-tree" />,
+    },
+    {
+      path: '/groups-tree',
+      element: <GroupsTreePage />,
+    },
+
+    // Fallback route in case an unknown route has been navigated to.
+    {
+      path: '*',
+      element: <Navigate to="/" />,
+    },
+  ];
+  const routeElement = useRoutes(routes);
+
+  return <React.Fragment>{routeElement}</React.Fragment>;
+};

--- a/frontend/src/components/main-page/routes.tsx
+++ b/frontend/src/components/main-page/routes.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
 
+import { AuthTokensPage } from './auth-tokens-page';
 import { GroupsTreePage } from './groups-tree-page/groups-tree-page';
 
 export const MainPageRoutes: React.FC = () => {
@@ -12,6 +13,10 @@ export const MainPageRoutes: React.FC = () => {
     {
       path: '/groups-tree',
       element: <GroupsTreePage />,
+    },
+    {
+      path: '/auth-tokens',
+      element: <AuthTokensPage />,
     },
 
     // Fallback route in case an unknown route has been navigated to.

--- a/frontend/src/components/main-page/services/service-docs-service.tsx
+++ b/frontend/src/components/main-page/services/service-docs-service.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { ListAllServiceDocs200ResponseData } from '../../../models/api';
+
+interface ServiceDocsService {
+  serviceDocs: ListAllServiceDocs200ResponseData;
+}
+function useServiceDocsService(
+  serviceDocs: ListAllServiceDocs200ResponseData,
+): ServiceDocsService {
+  return {
+    serviceDocs: serviceDocs,
+  };
+}
+
+const AuthDataServiceContext = React.createContext<
+  ServiceDocsService | undefined
+>(undefined);
+
+interface Props {
+  serviceDocs: ListAllServiceDocs200ResponseData;
+  children?: React.ReactNode;
+}
+export const ServiceDocsServiceContextProvider: React.FC<Props> = (props) => {
+  const serviceDocsService = useServiceDocsService(props.serviceDocs);
+
+  return (
+    <AuthDataServiceContext.Provider value={serviceDocsService}>
+      {props.children}
+    </AuthDataServiceContext.Provider>
+  );
+};
+
+export const useServiceDocsServiceContext = (): ServiceDocsService => {
+  const context = React.useContext(AuthDataServiceContext);
+  if (!context) {
+    throw Error(
+      'Your component does not seem to be part of the ServiceDocsServiceContext!',
+    );
+  }
+
+  return context;
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,13 +1,17 @@
+import { CssBaseline } from '@mui/material';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import { App } from './app';
+import './theme/main.scss';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <CssBaseline>
+      <App />
+    </CssBaseline>
   </React.StrictMode>,
 );

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
+
+import { LoginPage } from './components/login-page';
+import { MainPage } from './components/main-page';
+import { useAuthDataServiceContext } from './services/auth-data-service';
+
+export const AppRoutes: React.FC = () => {
+  const authService = useAuthDataServiceContext();
+
+  const routes: RouteObject[] = [
+    {
+      path: '/',
+      element: authService.state.accessAndRefreshToken ? (
+        <Navigate to="/main" />
+      ) : (
+        <Navigate to="/login" />
+      ),
+    },
+    {
+      path: '/login',
+      element: <LoginPage />,
+    },
+    {
+      path: '/main/*',
+      element: <MainPage />,
+    },
+
+    // Fallback route in case an unknown route has been navigated to.
+    {
+      path: '*',
+      element: <Navigate to="/" />,
+    },
+  ];
+  const routeElement = useRoutes(routes);
+
+  return <React.Fragment>{routeElement}</React.Fragment>;
+};

--- a/frontend/src/services/auth-data-service.tsx
+++ b/frontend/src/services/auth-data-service.tsx
@@ -82,10 +82,10 @@ interface Props {
   children?: React.ReactNode;
 }
 export const AuthDataServiceContextProvider: React.FC<Props> = (props) => {
-  const kernelService = useAuthDataService();
+  const authDataService = useAuthDataService();
 
   return (
-    <AuthDataServiceContext.Provider value={kernelService}>
+    <AuthDataServiceContext.Provider value={authDataService}>
       {props.children}
     </AuthDataServiceContext.Provider>
   );

--- a/frontend/src/services/auth-data-service.tsx
+++ b/frontend/src/services/auth-data-service.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const ACCESS_TOKEN_LOCALSTORAGE_KEY = 'msadoc--access-token';
 const REFRESH_TOKEN_LOCALSTORAGE_KEY = 'msadoc--refresh-token';
 
-interface AccessAndRefreshToken {
+export interface AccessAndRefreshToken {
   accessToken: string;
   refreshToken: string;
 }

--- a/frontend/src/services/auth-data-service.tsx
+++ b/frontend/src/services/auth-data-service.tsx
@@ -15,7 +15,7 @@ interface AuthDataService {
   state: State;
 
   /**
-   * Update the Access and Refresh Token.
+   * Set/Update the Access and Refresh Token.
    * This will not only update our State, but also store these tokens in LocalStorage.
    */
   setAccessAndRefreshToken: (newTokens: AccessAndRefreshToken) => void;
@@ -43,27 +43,33 @@ function useAuthDataService(): AuthDataService {
     };
   });
 
+  // Whenever the Access/Refresh Tokens in our State change, remember this in LocalStorage.
+  React.useEffect(() => {
+    if (!state.accessAndRefreshToken) {
+      localStorage.removeItem(ACCESS_TOKEN_LOCALSTORAGE_KEY);
+      localStorage.removeItem(REFRESH_TOKEN_LOCALSTORAGE_KEY);
+      return;
+    }
+
+    localStorage.setItem(
+      ACCESS_TOKEN_LOCALSTORAGE_KEY,
+      state.accessAndRefreshToken.accessToken,
+    );
+    localStorage.setItem(
+      REFRESH_TOKEN_LOCALSTORAGE_KEY,
+      state.accessAndRefreshToken.refreshToken,
+    );
+  }, [state.accessAndRefreshToken]);
+
   return {
     state: state,
 
     setAccessAndRefreshToken: (newTokens): void => {
       setState((state) => ({ ...state, accessAndRefreshToken: newTokens }));
-
-      localStorage.setItem(
-        ACCESS_TOKEN_LOCALSTORAGE_KEY,
-        newTokens.accessToken,
-      );
-      localStorage.setItem(
-        REFRESH_TOKEN_LOCALSTORAGE_KEY,
-        newTokens.refreshToken,
-      );
     },
 
     deleteAccessAndRefreshToken: (): void => {
       setState((state) => ({ ...state, accessAndRefreshToken: undefined }));
-
-      localStorage.removeItem(ACCESS_TOKEN_LOCALSTORAGE_KEY);
-      localStorage.removeItem(REFRESH_TOKEN_LOCALSTORAGE_KEY);
     },
   };
 }

--- a/frontend/src/theme/main.scss
+++ b/frontend/src/theme/main.scss
@@ -1,0 +1,12 @@
+@import '@fontsource/roboto/100.css';
+@import '@fontsource/roboto/300.css';
+@import '@fontsource/roboto/400.css';
+@import '@fontsource/roboto/500.css';
+@import '@fontsource/roboto/700.css';
+@import '@fontsource/roboto/900.css';
+
+html,
+body,
+#root {
+  height: 100%;
+}


### PR DESCRIPTION
This PR is part 3 of #4. The PR contributes the following:
- We now have a Router and 3 pages: `/login`, `/main/groups-tree`, and `/main/auth-tokens` (I honestly was not sure how to call the page where we list the groups, so I just called it GroupsTree for now).
  - The pages in `main` all have access to a shared `ServiceDocsService` which contains the current ServiceDocs. So we don't have to perform additional API requests when the user navigates around the `main` pages.
  - There is a "Reload Service Docs" button on the bottom left, so users are able to refresh the Service Docs if they want to. To improve the UX, I decided to implement this reloading in a way that component State is not lost when the user presses the button.
- We now use MaterialUI (MUI) for the frontend. This has one drawback: It slows down my VSCode dramatically. I have found a few Issues that report similar problems, but I assume this only affects a minority of developers.
- The Token Refresh logic was broken in the frontend (it would use the old token after performing a refresh, which would of course always result in a `401` error).
-  There is now a `.code-snippets` file for VSCode that makes it super easy to create new React Components by just typing "reactcomponent" and selecting the suggestion.

# Screenshots
![grafik](https://user-images.githubusercontent.com/8061217/191468925-305b8750-a36c-496c-9633-bc1672949ab2.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469036-f64c1192-373e-49fa-9577-1ee40215b8e4.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469096-71c3b12b-5a4c-465a-810d-45d5561f923a.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469189-64e216f2-b544-484b-b7b2-72dbd4d884f2.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469246-fd2de61e-ad4c-41a2-bc0f-a19de640fe1d.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469303-df29d2d1-2182-4b56-92df-109df0a856e7.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469397-84791c51-a313-4192-be13-5915fca50e70.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469426-980c23a4-c9e1-44ef-9c3b-96cbfc898095.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469536-a8633c3d-9a94-4ae8-816c-44c7ed670f47.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469601-e585d67a-f9a7-4428-97df-340a8c8789b9.png)
![grafik](https://user-images.githubusercontent.com/8061217/191469711-ca7244fb-8ac0-467b-9e5b-fbb406cdddf0.png)


