### PR TITLE
Define type-safe routes

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import { AppRoutes } from './routes';
+import { AppRouter } from './router';
 import { AuthDataServiceContextProvider } from './services/auth-data-service';
 import { HttpServiceContextProvider } from './services/http-service';
 
@@ -10,7 +10,7 @@ export const App: React.FC = () => {
     <BrowserRouter>
       <AuthDataServiceContextProvider>
         <HttpServiceContextProvider>
-          <AppRoutes />
+          <AppRouter />
         </HttpServiceContextProvider>
       </AuthDataServiceContextProvider>
     </BrowserRouter>

--- a/frontend/src/components/login-page/login-page.tsx
+++ b/frontend/src/components/login-page/login-page.tsx
@@ -4,6 +4,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { APP_ROUTES } from '../../routes';
 import { useHttpServiceContext } from '../../services/http-service';
 
 enum ViewState {
@@ -182,7 +183,7 @@ function useController(): Controller {
       );
 
       if (loginResponse.status === 200) {
-        navigate('/main');
+        navigate(APP_ROUTES.main);
         return;
       }
       if (loginResponse.status === 401) {

--- a/frontend/src/components/main-page/left-menu.tsx
+++ b/frontend/src/components/main-page/left-menu.tsx
@@ -3,6 +3,7 @@ import { Box, IconButton, Stack, Tooltip } from '@mui/material';
 import React from 'react';
 import { useMatch, useNavigate, useResolvedPath } from 'react-router-dom';
 
+import { MAIN_PAGE_ROUTES_ABS } from '../../routes';
 import { useAuthDataServiceContext } from '../../services/auth-data-service';
 
 interface Props {
@@ -23,14 +24,14 @@ export const LeftMenu: React.FC<Props> = (props) => {
     >
       <Stack sx={{ width: '100%' }}>
         <NavButtonWithRouterTarget
-          routerTarget="/main/groups-tree"
+          routerTarget={MAIN_PAGE_ROUTES_ABS.groupsTree}
           tooltipText="Groups Tree"
         >
           <AccountTree fontSize="inherit" />
         </NavButtonWithRouterTarget>
 
         <NavButtonWithRouterTarget
-          routerTarget="/main/auth-tokens"
+          routerTarget={MAIN_PAGE_ROUTES_ABS.authTokens}
           tooltipText="Auth Tokens"
         >
           <Key fontSize="inherit" />

--- a/frontend/src/components/main-page/main-page.tsx
+++ b/frontend/src/components/main-page/main-page.tsx
@@ -14,7 +14,7 @@ import { ListAllServiceDocs200ResponseData } from '../../models/api';
 import { useHttpServiceContext } from '../../services/http-service';
 
 import { LeftMenu } from './left-menu';
-import { MainPageRoutes } from './routes';
+import { MainPageRouter } from './router';
 import { ServiceDocsServiceContextProvider } from './services/service-docs-service';
 
 export const MainPage: React.FC = () => {
@@ -75,7 +75,7 @@ export const MainPage: React.FC = () => {
             <ServiceDocsServiceContextProvider
               serviceDocs={controller.state.serviceDocs}
             >
-              <MainPageRoutes />
+              <MainPageRouter />
             </ServiceDocsServiceContextProvider>
           )}
         </Box>

--- a/frontend/src/components/main-page/router.tsx
+++ b/frontend/src/components/main-page/router.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
 import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
 
+import { MAIN_PAGE_ROUTES_ABS, MAIN_PAGE_ROUTES_REL } from '../../routes';
+
 import { AuthTokensPage } from './auth-tokens-page';
 import { GroupsTreePage } from './groups-tree-page/groups-tree-page';
 
-export const MainPageRoutes: React.FC = () => {
+export const MainPageRouter: React.FC = () => {
   const routes: RouteObject[] = [
     {
       path: '/',
-      element: <Navigate to="/main/groups-tree" />,
+      element: <Navigate to={MAIN_PAGE_ROUTES_ABS.groupsTree} />,
     },
     {
-      path: '/groups-tree',
+      path: MAIN_PAGE_ROUTES_REL.groupsTree,
       element: <GroupsTreePage />,
     },
     {
-      path: '/auth-tokens',
+      path: MAIN_PAGE_ROUTES_REL.authTokens,
       element: <AuthTokensPage />,
     },
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,26 +3,27 @@ import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
 
 import { LoginPage } from './components/login-page';
 import { MainPage } from './components/main-page';
+import { APP_ROUTES } from './routes';
 import { useAuthDataServiceContext } from './services/auth-data-service';
 
-export const AppRoutes: React.FC = () => {
+export const AppRouter: React.FC = () => {
   const authService = useAuthDataServiceContext();
 
   const routes: RouteObject[] = [
     {
       path: '/',
       element: authService.state.accessAndRefreshToken ? (
-        <Navigate to="/main" />
+        <Navigate to={APP_ROUTES.main} />
       ) : (
-        <Navigate to="/login" />
+        <Navigate to={APP_ROUTES.login} />
       ),
     },
     {
-      path: '/login',
+      path: APP_ROUTES.login,
       element: <LoginPage />,
     },
     {
-      path: '/main/*',
+      path: APP_ROUTES.main + '/*',
       element: <MainPage />,
     },
 

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -1,0 +1,60 @@
+/*
+  All routes defined here are available both in a "relative" and an "absolute" version.
+  The "relative" routes are basically only used when registering them to the router.
+  The "absolute" routes are the ones that are used in all other cases - navigating to a page, reading router parameters, and more.
+  Thus, most of the time, you need to use the `*_ABS` routes.
+
+  Important: All routes are defined with the "as const" keyword. This makes type inference possible.
+*/
+
+// These are the only routes that don't have a "relative" and "absolute" variant, because both variants would be the same.
+export const APP_ROUTES = {
+  login: '/login',
+  main: '/main',
+} as const;
+
+export const MAIN_PAGE_ROUTES_REL = {
+  groupsTree: '/groups-tree',
+  authTokens: '/auth-tokens',
+} as const;
+export const MAIN_PAGE_ROUTES_ABS = buildAbsoluteRoutes(
+  MAIN_PAGE_ROUTES_REL,
+  APP_ROUTES.main,
+);
+
+/**
+ * A helper function that converts a relative route object to an absolute one.
+ * Technically, all it does is to build a new object where all values are prefixed with the prefix provided as second parameter. The return type is properly inferred (i.e. it has the actual string literal types instead of just being typed as "string"). This makes it easier and more type-safe to work with the router.
+ *
+ * Example:
+ * ```
+ * const myRelativeRoutes = {
+ *  route1: '/foo',
+ *  route2: '/bar',
+ * } as const;
+ *
+ * buildAbsoluteRoutes(myRelativeRoutes, '/example');
+ * // --> { route1: '/example/foo', route2: '/example/bar', };
+ * // Note that the TS type is also properly inferred.
+ * ```
+ */
+function buildAbsoluteRoutes<
+  TRelRecord extends Record<string, string>,
+  TPrefix extends string,
+>(relRecord: TRelRecord, prefix: TPrefix): Absolute<TRelRecord, TPrefix> {
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(relRecord)) {
+    result[key] = prefix + value;
+  }
+
+  return result as Absolute<TRelRecord, TPrefix>;
+}
+type Absolute<TRelRecord, TPrefix extends string> = TRelRecord extends Record<
+  string,
+  string
+>
+  ? {
+      [Key in keyof TRelRecord]: `${TPrefix}${TRelRecord[Key]}`;
+    }
+  : never;

--- a/frontend/src/services/http-service.tsx
+++ b/frontend/src/services/http-service.tsx
@@ -12,6 +12,7 @@ import {
   LoginHttpResponse,
   UnknownHttpError,
 } from '../models/api';
+import { APP_ROUTES } from '../routes';
 
 import {
   AccessAndRefreshToken,
@@ -133,7 +134,7 @@ function useHttpService(): HttpService {
       if (
         authDataService.state.accessAndRefreshToken?.refreshToken === undefined
       ) {
-        navigate('/login');
+        navigate(APP_ROUTES.login);
         resolve(undefined);
         return;
       }
@@ -163,7 +164,7 @@ function useHttpService(): HttpService {
           error: () => {
             // In the future, we might want to distinguish cases like "the client currently has no internet connection" and "the token is invalid". However, the following should be fine for now.
             authDataService.deleteAccessAndRefreshToken();
-            navigate('/login');
+            navigate(APP_ROUTES.login);
             resolve(undefined);
           },
         });
@@ -188,7 +189,7 @@ function useHttpService(): HttpService {
       }
 
       if (accessToken === undefined) {
-        navigate('/login');
+        navigate(APP_ROUTES.login);
         resolve({
           status: 0,
           data: undefined,


### PR DESCRIPTION
I noticed a pretty error-prone setup with our router: Whenever we would use functions like `navigate(...)`, we would simply pass a string as the target route. For example, to navigate to the "groups-tree" page, we would say `navigate('/main/groups-tree')`. This is not ideal because it makes refactoring pretty hard and typos cannot be detected during compile-time.

This PR addresses this: In `src/routes.ts`, there are now objects that explicitly define the router paths. To navigate to the aformentioned page, we would now use `navigate(MAIN_PAGE_ROUTES_ABS.groupsTree)`.

You might be wondering why there is an "ABS" at the end. Most of the time, we need the full URL like `/main/groups-tree`. However, when assigning our routes to the React Router, we also need the relative URL like `/groups-tree`. That's why there is both `MAIN_PAGE_ROUTES_ABS` and `MAIN_PAGE_ROUTES_REL`.

The routes are defined with the `as const` keyword so that further type inference is possible, like this one where we concatenate `APP_ROUTES.main` and `MAIN_PAGE_ROUTES_REL`:

![grafik](https://user-images.githubusercontent.com/8061217/191945594-44dd5a7b-7241-416e-a898-6a5341b9425b.png)
