### PR TITLE
Properly annotate optional Service Docs fields

### DIFF
--- a/client-generated/models/CreateServiceDocRequest.ts
+++ b/client-generated/models/CreateServiceDocRequest.ts
@@ -27,77 +27,77 @@ export interface CreateServiceDocRequest {
      * @type {string}
      * @memberof CreateServiceDocRequest
      */
-    group: string;
+    group?: string;
     /**
      * List of tags used to filter.
      * @type {Array<string>}
      * @memberof CreateServiceDocRequest
      */
-    tags: Array<string>;
+    tags?: Array<string>;
     /**
      * URL to code repository.
      * @type {string}
      * @memberof CreateServiceDocRequest
      */
-    repository: string;
+    repository?: string;
     /**
      * URL to task board.
      * @type {string}
      * @memberof CreateServiceDocRequest
      */
-    taskBoard: string;
+    taskBoard?: string;
     /**
      * List of consumed API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocRequest
      */
-    consumedAPIs: Array<string>;
+    consumedAPIs?: Array<string>;
     /**
      * List of provided API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocRequest
      */
-    providedAPIs: Array<string>;
+    providedAPIs?: Array<string>;
     /**
      * List of produced event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocRequest
      */
-    producedEvents: Array<string>;
+    producedEvents?: Array<string>;
     /**
      * List of consumed event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocRequest
      */
-    consumedEvents: Array<string>;
+    consumedEvents?: Array<string>;
     /**
      * URL to development documentation.
      * @type {string}
      * @memberof CreateServiceDocRequest
      */
-    developmentDocumentation: string;
+    developmentDocumentation?: string;
     /**
      * URL to deployment documentation.
      * @type {string}
      * @memberof CreateServiceDocRequest
      */
-    deploymentDocumentation: string;
+    deploymentDocumentation?: string;
     /**
      * URL to API documentation.
      * @type {string}
      * @memberof CreateServiceDocRequest
      */
-    apiDocumentation: string;
+    apiDocumentation?: string;
     /**
      * Responsible team identifier. Used for matching multiple services to teams
      * @type {string}
      * @memberof CreateServiceDocRequest
      */
-    responsibleTeam: string;
+    responsibleTeam?: string;
     /**
      * List of responsible person identifiers.
      * @type {Array<string>}
      * @memberof CreateServiceDocRequest
      */
-    responsibles: Array<string>;
+    responsibles?: Array<string>;
 }

--- a/client-generated/models/CreateServiceDocResponse.ts
+++ b/client-generated/models/CreateServiceDocResponse.ts
@@ -27,79 +27,79 @@ export interface CreateServiceDocResponse {
      * @type {string}
      * @memberof CreateServiceDocResponse
      */
-    group: string;
+    group?: string;
     /**
      * List of tags used to filter.
      * @type {Array<string>}
      * @memberof CreateServiceDocResponse
      */
-    tags: Array<string>;
+    tags?: Array<string>;
     /**
      * URL to code repository.
      * @type {string}
      * @memberof CreateServiceDocResponse
      */
-    repository: string;
+    repository?: string;
     /**
      * URL to task board.
      * @type {string}
      * @memberof CreateServiceDocResponse
      */
-    taskBoard: string;
+    taskBoard?: string;
     /**
      * List of consumed API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocResponse
      */
-    consumedAPIs: Array<string>;
+    consumedAPIs?: Array<string>;
     /**
      * List of provided API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocResponse
      */
-    providedAPIs: Array<string>;
+    providedAPIs?: Array<string>;
     /**
      * List of produced event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocResponse
      */
-    producedEvents: Array<string>;
+    producedEvents?: Array<string>;
     /**
      * List of consumed event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof CreateServiceDocResponse
      */
-    consumedEvents: Array<string>;
+    consumedEvents?: Array<string>;
     /**
      * URL to development documentation.
      * @type {string}
      * @memberof CreateServiceDocResponse
      */
-    developmentDocumentation: string;
+    developmentDocumentation?: string;
     /**
      * URL to deployment documentation.
      * @type {string}
      * @memberof CreateServiceDocResponse
      */
-    deploymentDocumentation: string;
+    deploymentDocumentation?: string;
     /**
      * URL to API documentation.
      * @type {string}
      * @memberof CreateServiceDocResponse
      */
-    apiDocumentation: string;
+    apiDocumentation?: string;
     /**
      * Responsible team identifier. Used for matching multiple services to teams
      * @type {string}
      * @memberof CreateServiceDocResponse
      */
-    responsibleTeam: string;
+    responsibleTeam?: string;
     /**
      * List of responsible person identifiers.
      * @type {Array<string>}
      * @memberof CreateServiceDocResponse
      */
-    responsibles: Array<string>;
+    responsibles?: Array<string>;
     /**
      * @type {string}
      * @memberof CreateServiceDocResponse

--- a/client-generated/models/DeleteServiceDocResponse.ts
+++ b/client-generated/models/DeleteServiceDocResponse.ts
@@ -27,79 +27,79 @@ export interface DeleteServiceDocResponse {
      * @type {string}
      * @memberof DeleteServiceDocResponse
      */
-    group: string;
+    group?: string;
     /**
      * List of tags used to filter.
      * @type {Array<string>}
      * @memberof DeleteServiceDocResponse
      */
-    tags: Array<string>;
+    tags?: Array<string>;
     /**
      * URL to code repository.
      * @type {string}
      * @memberof DeleteServiceDocResponse
      */
-    repository: string;
+    repository?: string;
     /**
      * URL to task board.
      * @type {string}
      * @memberof DeleteServiceDocResponse
      */
-    taskBoard: string;
+    taskBoard?: string;
     /**
      * List of consumed API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof DeleteServiceDocResponse
      */
-    consumedAPIs: Array<string>;
+    consumedAPIs?: Array<string>;
     /**
      * List of provided API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof DeleteServiceDocResponse
      */
-    providedAPIs: Array<string>;
+    providedAPIs?: Array<string>;
     /**
      * List of produced event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof DeleteServiceDocResponse
      */
-    producedEvents: Array<string>;
+    producedEvents?: Array<string>;
     /**
      * List of consumed event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof DeleteServiceDocResponse
      */
-    consumedEvents: Array<string>;
+    consumedEvents?: Array<string>;
     /**
      * URL to development documentation.
      * @type {string}
      * @memberof DeleteServiceDocResponse
      */
-    developmentDocumentation: string;
+    developmentDocumentation?: string;
     /**
      * URL to deployment documentation.
      * @type {string}
      * @memberof DeleteServiceDocResponse
      */
-    deploymentDocumentation: string;
+    deploymentDocumentation?: string;
     /**
      * URL to API documentation.
      * @type {string}
      * @memberof DeleteServiceDocResponse
      */
-    apiDocumentation: string;
+    apiDocumentation?: string;
     /**
      * Responsible team identifier. Used for matching multiple services to teams
      * @type {string}
      * @memberof DeleteServiceDocResponse
      */
-    responsibleTeam: string;
+    responsibleTeam?: string;
     /**
      * List of responsible person identifiers.
      * @type {Array<string>}
      * @memberof DeleteServiceDocResponse
      */
-    responsibles: Array<string>;
+    responsibles?: Array<string>;
     /**
      * @type {string}
      * @memberof DeleteServiceDocResponse

--- a/client-generated/models/GetServiceDocResponse.ts
+++ b/client-generated/models/GetServiceDocResponse.ts
@@ -27,79 +27,79 @@ export interface GetServiceDocResponse {
      * @type {string}
      * @memberof GetServiceDocResponse
      */
-    group: string;
+    group?: string;
     /**
      * List of tags used to filter.
      * @type {Array<string>}
      * @memberof GetServiceDocResponse
      */
-    tags: Array<string>;
+    tags?: Array<string>;
     /**
      * URL to code repository.
      * @type {string}
      * @memberof GetServiceDocResponse
      */
-    repository: string;
+    repository?: string;
     /**
      * URL to task board.
      * @type {string}
      * @memberof GetServiceDocResponse
      */
-    taskBoard: string;
+    taskBoard?: string;
     /**
      * List of consumed API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof GetServiceDocResponse
      */
-    consumedAPIs: Array<string>;
+    consumedAPIs?: Array<string>;
     /**
      * List of provided API identifiers. API identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof GetServiceDocResponse
      */
-    providedAPIs: Array<string>;
+    providedAPIs?: Array<string>;
     /**
      * List of produced event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof GetServiceDocResponse
      */
-    producedEvents: Array<string>;
+    producedEvents?: Array<string>;
     /**
      * List of consumed event identifiers. Event identifier matched for dependency analysis.
      * @type {Array<string>}
      * @memberof GetServiceDocResponse
      */
-    consumedEvents: Array<string>;
+    consumedEvents?: Array<string>;
     /**
      * URL to development documentation.
      * @type {string}
      * @memberof GetServiceDocResponse
      */
-    developmentDocumentation: string;
+    developmentDocumentation?: string;
     /**
      * URL to deployment documentation.
      * @type {string}
      * @memberof GetServiceDocResponse
      */
-    deploymentDocumentation: string;
+    deploymentDocumentation?: string;
     /**
      * URL to API documentation.
      * @type {string}
      * @memberof GetServiceDocResponse
      */
-    apiDocumentation: string;
+    apiDocumentation?: string;
     /**
      * Responsible team identifier. Used for matching multiple services to teams
      * @type {string}
      * @memberof GetServiceDocResponse
      */
-    responsibleTeam: string;
+    responsibleTeam?: string;
     /**
      * List of responsible person identifiers.
      * @type {Array<string>}
      * @memberof GetServiceDocResponse
      */
-    responsibles: Array<string>;
+    responsibles?: Array<string>;
     /**
      * @type {string}
      * @memberof GetServiceDocResponse

--- a/server/src/service-docs/service-doc.dto.ts
+++ b/server/src/service-docs/service-doc.dto.ts
@@ -9,21 +9,25 @@ export class CreateServiceDocRequest {
   @ApiProperty({
     description:
       'Name of the group. Used as identifier to match with group meta-data. Hierarchical groups separated by a dot, e.g. "group.sub-group.sub-sub-group"',
+    required: false,
   })
   group?: string;
 
   @ApiProperty({
     description: 'List of tags used to filter.',
+    required: false,
   })
   tags?: string[];
 
   @ApiProperty({
     description: 'URL to code repository.',
+    required: false,
   })
   repository?: string;
 
   @ApiProperty({
     description: 'URL to task board.',
+    required: false,
   })
   taskBoard?: string;
 
@@ -32,24 +36,28 @@ export class CreateServiceDocRequest {
   @ApiProperty({
     description:
       'List of consumed API identifiers. API identifier matched for dependency analysis.',
+    required: false,
   })
   consumedAPIs?: string[];
 
   @ApiProperty({
     description:
       'List of provided API identifiers. API identifier matched for dependency analysis.',
+    required: false,
   })
   providedAPIs?: string[];
 
   @ApiProperty({
     description:
       'List of produced event identifiers. Event identifier matched for dependency analysis.',
+    required: false,
   })
   producedEvents?: string[];
 
   @ApiProperty({
     description:
       'List of consumed event identifiers. Event identifier matched for dependency analysis.',
+    required: false,
   })
   consumedEvents?: string[];
 
@@ -57,16 +65,19 @@ export class CreateServiceDocRequest {
 
   @ApiProperty({
     description: 'URL to development documentation.',
+    required: false,
   })
   developmentDocumentation?: string;
 
   @ApiProperty({
     description: 'URL to deployment documentation.',
+    required: false,
   })
   deploymentDocumentation?: string;
 
   @ApiProperty({
     description: 'URL to API documentation.',
+    required: false,
   })
   apiDocumentation?: string;
 
@@ -75,11 +86,13 @@ export class CreateServiceDocRequest {
   @ApiProperty({
     description:
       'Responsible team identifier. Used for matching multiple services to teams',
+    required: false,
   })
   responsibleTeam?: string;
 
   @ApiProperty({
     description: 'List of responsible person identifiers.',
+    required: false,
   })
   responsibles?: string[];
 }


### PR DESCRIPTION
It seems like the Swagger/OpenAPI generator is not able to automatically determine if a property is optional. Thus, fields like `group` were all typed as `group: string` instead of `group?: string` in the generated client library. This PR fixes this by adding `required: false` to all optional fields.

This was actually pretty surprising, because the server does not seem to complain when you send a request to create a new Service Doc without adding all required properties. @georg-schwarz We should talk about that in a meeting, because it could have security implications.

Now, only the `name` is required (see the red `*`):
![grafik](https://user-images.githubusercontent.com/8061217/192793715-14486ccf-e1c2-4181-a5e8-ccf207e5d6f4.png)
