### PR TITLE
Groups tree basics

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useMatch } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
+import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+import {
+  ServiceDocsGroup,
+  ServiceDocsRootGroup,
+  getGroupByIdentifier,
+} from '../../utils/service-docs-utils';
+
+export const GroupDetails: React.FC = () => {
+  const controller = useController();
+
+  return (
+    <React.Fragment>
+      Group Details {JSON.stringify(controller.group)}
+    </React.Fragment>
+  );
+};
+
+interface Controller {
+  group: ServiceDocsRootGroup | ServiceDocsGroup | undefined;
+}
+function useController(): Controller {
+  const groupRouterMatch = useMatch(GROUPS_TREE_ROUTES_ABS.group);
+  const rootRouterMatch = useMatch(GROUPS_TREE_ROUTES_ABS.root);
+
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const group = React.useMemo(():
+    | ServiceDocsRootGroup
+    | ServiceDocsGroup
+    | undefined => {
+    if (groupRouterMatch && groupRouterMatch.params.group !== undefined) {
+      return getGroupByIdentifier(
+        groupRouterMatch.params.group,
+        serviceDocsService.groupsTree,
+      );
+    }
+    if (rootRouterMatch) {
+      return serviceDocsService.groupsTree;
+    }
+
+    console.warn(
+      'Neither the group route nor the root route matched. This should not happen.',
+    );
+    return undefined;
+  }, [groupRouterMatch, rootRouterMatch, serviceDocsService.groupsTree]);
+
+  return {
+    group: group,
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/group-details/index.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/group-details/index.tsx
@@ -1,0 +1,1 @@
+export { GroupDetails } from './group-details';

--- a/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
@@ -1,26 +1,27 @@
 import { Box } from '@mui/material';
-import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
 
-import { useServiceDocsServiceContext } from '../services/service-docs-service';
+import { GroupsTreePageRouter } from './router';
+import { Tree } from './tree';
 
 export const GroupsTreePage: React.FC = () => {
-  const controller = useController();
-
   return (
-    <Box sx={{ height: '100%', overflowX: 'hidden', overflowY: 'auto' }}>
-      {JSON.stringify(controller.serviceDocs)}
+    <Box sx={{ height: '100%', overflow: 'hidden', display: 'flex' }}>
+      <Box
+        sx={{
+          height: '100%',
+          overflow: 'auto',
+          width: '300px',
+          flexShrink: 0,
+          background: (theme) => theme.palette.grey[100],
+        }}
+      >
+        <Tree />
+      </Box>
+
+      <Box sx={{ height: '100%', overflow: 'auto', flexGrow: 1 }}>
+        <GroupsTreePageRouter />
+      </Box>
     </Box>
   );
 };
-
-interface Controller {
-  serviceDocs: GetServiceDocResponse[];
-}
-function useController(): Controller {
-  const serviceDocsService = useServiceDocsServiceContext();
-
-  return {
-    serviceDocs: serviceDocsService.serviceDocs,
-  };
-}

--- a/frontend/src/components/main-page/groups-tree-page/router.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/router.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
+
+import {
+  GROUPS_TREE_ROUTES_ABS,
+  GROUPS_TREE_ROUTES_REL,
+} from '../../../routes';
+
+import { GroupDetails } from './group-details';
+import { ServiceDetails } from './service-details';
+
+export const GroupsTreePageRouter: React.FC = () => {
+  const routes: RouteObject[] = [
+    {
+      path: '/',
+      element: <Navigate to={GROUPS_TREE_ROUTES_ABS.root} />,
+    },
+    {
+      path: GROUPS_TREE_ROUTES_REL.root,
+      element: <GroupDetails />,
+    },
+    {
+      path: GROUPS_TREE_ROUTES_REL.group,
+      element: <GroupDetails />,
+    },
+    {
+      path: GROUPS_TREE_ROUTES_REL.service,
+      element: <ServiceDetails />,
+    },
+
+    // Fallback route in case an unknown route has been navigated to.
+    {
+      path: '*',
+      element: <Navigate to={GROUPS_TREE_ROUTES_ABS.root} />,
+    },
+  ];
+  const routeElement = useRoutes(routes);
+
+  return <React.Fragment>{routeElement}</React.Fragment>;
+};

--- a/frontend/src/components/main-page/groups-tree-page/service-details/index.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/index.tsx
@@ -1,0 +1,1 @@
+export { ServiceDetails } from './service-details';

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -1,0 +1,45 @@
+import { GetServiceDocResponse } from 'msadoc-client';
+import React from 'react';
+import { useMatch } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
+import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+
+export const ServiceDetails: React.FC = () => {
+  const controller = useController();
+
+  return (
+    <React.Fragment>
+      Service Details {JSON.stringify(controller.service)}
+    </React.Fragment>
+  );
+};
+
+interface Controller {
+  service: GetServiceDocResponse | undefined;
+}
+function useController(): Controller {
+  const routerMatch = useMatch(GROUPS_TREE_ROUTES_ABS.service);
+
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const service = React.useMemo((): GetServiceDocResponse | undefined => {
+    if (!routerMatch || routerMatch.params.service === undefined) {
+      console.warn(
+        'The service route was not matched. This should not happen.',
+      );
+      return undefined;
+    }
+
+    return serviceDocsService.serviceDocs.find((item) => {
+      if (item.name !== routerMatch.params.service) {
+        return false;
+      }
+      return true;
+    });
+  }, [routerMatch, serviceDocsService.serviceDocs]);
+
+  return {
+    service: service,
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
@@ -1,0 +1,147 @@
+import { ChevronRight, ExpandMore } from '@mui/icons-material';
+import {
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
+import React from 'react';
+import { generatePath, useMatch, useNavigate } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
+import { ServiceDocsGroup } from '../../utils/service-docs-utils';
+
+import { ServiceItem } from './service-item';
+
+interface Props {
+  group: ServiceDocsGroup;
+
+  /**
+   * How deep is this item in the tree?
+   * This value is especially used to properly indent the item.
+   */
+  depth: number;
+}
+export const GroupItem: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <React.Fragment>
+      <ListItemButton
+        sx={{
+          pl: props.depth * 4,
+          background: (theme) =>
+            controller.isSelected ? theme.palette.primary.main : undefined,
+          color: (theme) =>
+            controller.isSelected
+              ? theme.palette.primary.contrastText
+              : undefined,
+          '&:hover': {
+            background: (theme) =>
+              controller.isSelected ? theme.palette.primary.main : undefined,
+            color: (theme) =>
+              controller.isSelected
+                ? theme.palette.primary.contrastText
+                : undefined,
+          },
+        }}
+        onClick={(): void => controller.navigateToThisGroup()}
+      >
+        {/* 
+          In the following, we use "align-self: stretch" to improve the UX:
+          The area where the user is able to click should be as large as possible so that the user does not accidentally click on the parent element.
+        */}
+        <ListItemIcon
+          sx={{
+            display: 'flex',
+            alignSelf: 'stretch',
+            alignItems: 'center',
+            color: 'inherit',
+          }}
+          onMouseDown={(e): void => {
+            // Disable the "ripple effect" on the button.
+            e.stopPropagation();
+          }}
+          onClick={(e): void => {
+            e.stopPropagation();
+            controller.toggleIsCollapsed();
+          }}
+        >
+          {controller.state.isCollapsed ? <ChevronRight /> : <ExpandMore />}
+        </ListItemIcon>
+        <ListItemText primary={props.group.name} />
+      </ListItemButton>
+
+      {!controller.state.isCollapsed && (
+        <React.Fragment>
+          <List disablePadding>
+            {Object.values(props.group.childGroups).map((childGroup) => (
+              <GroupItem
+                key={childGroup.identifier}
+                group={childGroup}
+                depth={props.depth + 1}
+              />
+            ))}
+          </List>
+
+          <List component="div" disablePadding>
+            {props.group.services.map((service) => (
+              <ServiceItem
+                key={service.name}
+                service={service}
+                depth={props.depth + 1}
+              />
+            ))}
+          </List>
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  );
+};
+
+interface State {
+  isCollapsed: boolean;
+}
+interface Controller {
+  state: State;
+
+  isSelected: boolean;
+
+  navigateToThisGroup: () => void;
+  toggleIsCollapsed: () => void;
+}
+function useController(props: Props): Controller {
+  const navigate = useNavigate();
+  const routeMatch = useMatch(GROUPS_TREE_ROUTES_ABS.group);
+
+  const [state, setState] = React.useState<State>({
+    isCollapsed: true,
+  });
+
+  const isSelected = ((): boolean => {
+    if (!routeMatch) {
+      return false;
+    }
+    if (routeMatch.params.group !== props.group.identifier) {
+      return false;
+    }
+    return true;
+  })();
+
+  return {
+    state: state,
+
+    isSelected: isSelected,
+
+    navigateToThisGroup: (): void => {
+      navigate(
+        generatePath(GROUPS_TREE_ROUTES_ABS.group, {
+          group: props.group.identifier,
+        }),
+      );
+    },
+    toggleIsCollapsed: (): void => {
+      setState((state) => ({ ...state, isCollapsed: !state.isCollapsed }));
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/tree/index.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/index.tsx
@@ -1,0 +1,1 @@
+export { Tree } from './tree';

--- a/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
@@ -1,0 +1,79 @@
+import { DatasetOutlined } from '@mui/icons-material';
+import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import React from 'react';
+import { useMatch, useNavigate } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
+import { ServiceDocsRootGroup } from '../../utils/service-docs-utils';
+
+import { GroupItem } from './group-item';
+import { ServiceItem } from './service-item';
+
+interface Props {
+  rootGroup: ServiceDocsRootGroup;
+}
+export const RootItem: React.FC<Props> = (props) => {
+  const controller = useController();
+
+  return (
+    <React.Fragment>
+      <ListItemButton
+        sx={{
+          background: (theme) =>
+            controller.isSelected ? theme.palette.primary.main : undefined,
+          color: (theme) =>
+            controller.isSelected
+              ? theme.palette.primary.contrastText
+              : undefined,
+          '&:hover': {
+            background: (theme) =>
+              controller.isSelected ? theme.palette.primary.main : undefined,
+            color: (theme) =>
+              controller.isSelected
+                ? theme.palette.primary.contrastText
+                : undefined,
+          },
+        }}
+        onClick={(): void => controller.navigateToRoot()}
+      >
+        <ListItemIcon sx={{ color: 'inherit' }}>
+          <DatasetOutlined />
+        </ListItemIcon>
+        <ListItemText primary="Root" />
+      </ListItemButton>
+
+      {Object.values(props.rootGroup.childGroups).map((childGroup) => (
+        <GroupItem key={childGroup.identifier} group={childGroup} depth={1} />
+      ))}
+
+      {props.rootGroup.services.map((service) => (
+        <ServiceItem key={service.name} service={service} depth={1} />
+      ))}
+    </React.Fragment>
+  );
+};
+
+interface Controller {
+  isSelected: boolean;
+
+  navigateToRoot: () => void;
+}
+function useController(): Controller {
+  const navigate = useNavigate();
+  const routeMatch = useMatch(GROUPS_TREE_ROUTES_ABS.root);
+
+  const isSelected = ((): boolean => {
+    if (!routeMatch) {
+      return false;
+    }
+    return true;
+  })();
+
+  return {
+    isSelected: isSelected,
+
+    navigateToRoot: (): void => {
+      navigate(GROUPS_TREE_ROUTES_ABS.root);
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
@@ -1,0 +1,80 @@
+import { CenterFocusStrongOutlined } from '@mui/icons-material';
+import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import { GetServiceDocResponse } from 'msadoc-client';
+import React from 'react';
+import { generatePath, useMatch, useNavigate } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
+
+interface Props {
+  service: GetServiceDocResponse;
+
+  /**
+   * How deep is this item in the tree?
+   * This value is especially used to properly indent the item.
+   */
+  depth: number;
+}
+export const ServiceItem: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <ListItemButton
+      sx={{
+        pl: props.depth * 4,
+        background: (theme) =>
+          controller.isSelected ? theme.palette.primary.main : undefined,
+        color: (theme) =>
+          controller.isSelected
+            ? theme.palette.primary.contrastText
+            : undefined,
+        '&:hover': {
+          background: (theme) =>
+            controller.isSelected ? theme.palette.primary.main : undefined,
+          color: (theme) =>
+            controller.isSelected
+              ? theme.palette.primary.contrastText
+              : undefined,
+        },
+      }}
+      onClick={(): void => controller.navigateToThisService()}
+    >
+      <ListItemIcon sx={{ color: 'inherit' }}>
+        <CenterFocusStrongOutlined />
+      </ListItemIcon>
+      <ListItemText primary={props.service.name} />
+    </ListItemButton>
+  );
+};
+
+interface Controller {
+  isSelected: boolean;
+
+  navigateToThisService: () => void;
+}
+function useController(props: Props): Controller {
+  const navigate = useNavigate();
+  const routeMatch = useMatch(GROUPS_TREE_ROUTES_ABS.service);
+
+  const isSelected = ((): boolean => {
+    if (!routeMatch) {
+      return false;
+    }
+    if (routeMatch.params.service !== props.service.name) {
+      return false;
+    }
+    return true;
+  })();
+
+  return {
+    isSelected: isSelected,
+
+    navigateToThisService: (): void => {
+      navigate(
+        generatePath(GROUPS_TREE_ROUTES_ABS.service, {
+          service: props.service.name,
+        }),
+      );
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/tree/tree.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/tree.tsx
@@ -1,0 +1,28 @@
+import { List } from '@mui/material';
+import React from 'react';
+
+import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+import { ServiceDocsRootGroup } from '../../utils/service-docs-utils';
+
+import { RootItem } from './root-item';
+
+export const Tree: React.FC = () => {
+  const controller = useController();
+
+  return (
+    <List sx={{ minWidth: 'min-content' }} component="div">
+      <RootItem rootGroup={controller.rootGroup} />
+    </List>
+  );
+};
+
+interface Controller {
+  rootGroup: ServiceDocsRootGroup;
+}
+function useController(): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  return {
+    rootGroup: serviceDocsService.groupsTree,
+  };
+}

--- a/frontend/src/components/main-page/router.tsx
+++ b/frontend/src/components/main-page/router.tsx
@@ -13,7 +13,7 @@ export const MainPageRouter: React.FC = () => {
       element: <Navigate to={MAIN_PAGE_ROUTES_ABS.groupsTree} />,
     },
     {
-      path: MAIN_PAGE_ROUTES_REL.groupsTree,
+      path: MAIN_PAGE_ROUTES_REL.groupsTree + '/*',
       element: <GroupsTreePage />,
     },
     {
@@ -24,7 +24,7 @@ export const MainPageRouter: React.FC = () => {
     // Fallback route in case an unknown route has been navigated to.
     {
       path: '*',
-      element: <Navigate to="/" />,
+      element: <Navigate to={MAIN_PAGE_ROUTES_ABS.groupsTree} />,
     },
   ];
   const routeElement = useRoutes(routes);

--- a/frontend/src/components/main-page/services/service-docs-service.tsx
+++ b/frontend/src/components/main-page/services/service-docs-service.tsx
@@ -1,14 +1,26 @@
 import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
 
+import {
+  ServiceDocsRootGroup,
+  buildGroupsTree,
+} from '../utils/service-docs-utils';
+
 interface ServiceDocsService {
   serviceDocs: GetServiceDocResponse[];
+  groupsTree: ServiceDocsRootGroup;
 }
 function useServiceDocsService(
   serviceDocs: GetServiceDocResponse[],
 ): ServiceDocsService {
+  const groupsTree = React.useMemo(
+    (): ServiceDocsRootGroup => buildGroupsTree(serviceDocs),
+    [serviceDocs],
+  );
+
   return {
     serviceDocs: serviceDocs,
+    groupsTree: groupsTree,
   };
 }
 

--- a/frontend/src/components/main-page/utils/service-docs-utils.ts
+++ b/frontend/src/components/main-page/utils/service-docs-utils.ts
@@ -1,0 +1,104 @@
+import { GetServiceDocResponse } from 'msadoc-client';
+
+export interface ServiceDocsGroup {
+  /**
+   * The `name` of a group is the last part of its `identifier`.
+   *
+   * Example: If the `identifier` is `foo.bar.baz`, then the `name` is `baz`.
+   */
+  name: string;
+  /**
+   * The unique identifier of this group like `foo.bar.baz`.
+   */
+  identifier: string;
+
+  /**
+   * The direct children of this group.
+   *
+   * The object keys are the names of the respective child group.
+   * (Compared to just using an array, this enables a faster lookup of groups.)
+   */
+  childGroups: { [groupName: string]: ServiceDocsGroup };
+
+  /**
+   * The services that belong to this group.
+   */
+  services: GetServiceDocResponse[];
+}
+export type ServiceDocsRootGroup = Omit<
+  ServiceDocsGroup,
+  'name' | 'identifier'
+>;
+
+export function buildGroupsTree(
+  serviceDocs: GetServiceDocResponse[],
+): ServiceDocsRootGroup {
+  const rootGroup: ServiceDocsRootGroup = {
+    childGroups: {},
+    services: [],
+  };
+
+  for (const singleServiceDoc of serviceDocs) {
+    let group = rootGroup;
+
+    // By default, we add the service to the root group. But if the service has the `group` attribute, then we want to add it to this specified group instead.
+    if (singleServiceDoc.group !== undefined) {
+      group = addGroupIfNotExists(singleServiceDoc.group, rootGroup);
+    }
+
+    group.services.push(singleServiceDoc);
+  }
+
+  return rootGroup;
+}
+
+export function getGroupByIdentifier(
+  groupIdentifier: string,
+  groupsTree: ServiceDocsRootGroup,
+): ServiceDocsGroup | undefined {
+  const splitGroupIdentifier = groupIdentifier.split('.');
+  let currentGroup = groupsTree;
+  for (const identifierPart of splitGroupIdentifier) {
+    const nextGroup = currentGroup.childGroups[identifierPart];
+    if (!nextGroup) {
+      return undefined;
+    }
+    currentGroup = nextGroup;
+  }
+  return currentGroup as ServiceDocsGroup;
+}
+
+function addGroupIfNotExists(
+  groupIdentifier: string,
+  rootGroup: ServiceDocsRootGroup,
+): ServiceDocsGroup | ServiceDocsRootGroup {
+  const splitGroupIdentifier = groupIdentifier.split('.');
+  if (splitGroupIdentifier[0] === undefined) {
+    // This should not happen.
+    return rootGroup;
+  }
+  let currentGroup = rootGroup;
+  for (let i = 0; i < splitGroupIdentifier.length; i++) {
+    const groupName = splitGroupIdentifier[i];
+    if (groupName === undefined) {
+      // This should not happen.
+      continue;
+    }
+
+    let childGroup = currentGroup.childGroups[groupName];
+    if (!childGroup) {
+      const identifier = splitGroupIdentifier.slice(0, i + 1).join('.');
+      childGroup = {
+        name: groupName,
+        identifier: identifier,
+        childGroups: {},
+        services: [],
+      };
+      currentGroup.childGroups[groupName] = childGroup;
+    }
+
+    currentGroup = childGroup;
+  }
+
+  return currentGroup;
+}

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -22,6 +22,16 @@ export const MAIN_PAGE_ROUTES_ABS = buildAbsoluteRoutes(
   APP_ROUTES.main,
 );
 
+export const GROUPS_TREE_ROUTES_REL = {
+  root: '/root',
+  group: '/group/:group',
+  service: '/service/:service',
+} as const;
+export const GROUPS_TREE_ROUTES_ABS = buildAbsoluteRoutes(
+  GROUPS_TREE_ROUTES_REL,
+  MAIN_PAGE_ROUTES_ABS.groupsTree,
+);
+
 /**
  * A helper function that converts a relative route object to an absolute one.
  * Technically, all it does is to build a new object where all values are prefixed with the prefix provided as second parameter. The return type is properly inferred (i.e. it has the actual string literal types instead of just being typed as "string"). This makes it easier and more type-safe to work with the router.


### PR DESCRIPTION
This PR adds a tree view on the left, so that users are now able to easily navigate through the groups and services. For this, a recursive data structure called `ServiceDocsGroup` is created, which contains a group name/identifier, the direct children of the group and the services belonging to the group.

<details>
  <summary>Example</summary>

If an identifier like `foo.bar` is used for a group, a data structure like this is created:

``` js
{
  childGroups: {
    foo: {
      name: 'foo',
      identifier: 'foo',
      childGroups: {
        bar: {
          name: 'bar',
          identifier: 'foo.bar',
          childGroups: {},
          services: [ /* The service(s) that included the group identifier are stored here. */]
        }
      },
      services: []
    }
  },
  services: [
    // The services that don't belong to any group are added here.
  ]
}
```

This makes it pretty easy to build our tree visualization.

</details>


A user can click on the Root item, on a Group, or on a Service, in order to see more details on the right. This is handled using the Router, because I believe we might later on want to be able to navigate to a particular Service or Group using the Router (e.g. when using a search feature on another page).

The content on the right is currently just the stringified `ServiceDocsGroup` item.

# Screenshots
![grafik](https://user-images.githubusercontent.com/8061217/192798407-a0b971a4-51fd-41c7-b6eb-c3597ecf4f5a.png)
![grafik](https://user-images.githubusercontent.com/8061217/192798455-9c8e5525-2266-4f16-984b-9e4e34a348c7.png)
![grafik](https://user-images.githubusercontent.com/8061217/192798487-670eeb0c-2eea-43f9-b1e8-6ee892ccadd0.png)
![grafik](https://user-images.githubusercontent.com/8061217/192798540-a4d43444-973f-424b-99eb-c631fab80972.png)
![grafik](https://user-images.githubusercontent.com/8061217/192799453-d77cb7bb-64aa-4028-ac22-fbb13e953557.png)

