### PR TITLE
Show basic service details

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -1,3 +1,12 @@
+import { Badge, Code, Group, TaskAlt } from '@mui/icons-material';
+import {
+  Box,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
 import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
 import { useMatch } from 'react-router-dom';
@@ -10,7 +19,66 @@ export const ServiceDetails: React.FC = () => {
 
   return (
     <React.Fragment>
-      Service Details {JSON.stringify(controller.service)}
+      {controller.service && (
+        <Box
+          sx={{
+            overflowX: 'hidden',
+            overflowY: 'auto',
+            padding: 4,
+            maxWidth: '700px',
+          }}
+        >
+          <Typography variant="h3">Base Information</Typography>
+
+          <List>
+            <ListItem divider>
+              <ListItemIcon>
+                <Badge />
+              </ListItemIcon>
+              <ListItemText
+                primary={controller.service.name}
+                secondary="Name"
+              />
+            </ListItem>
+
+            {controller.service.group !== undefined && (
+              <ListItem divider>
+                <ListItemIcon>
+                  <Group />
+                </ListItemIcon>
+                <ListItemText
+                  primary={controller.service.group}
+                  secondary="Group"
+                />
+              </ListItem>
+            )}
+
+            {controller.service.repository !== undefined && (
+              <ListItem divider>
+                <ListItemIcon>
+                  <Code />
+                </ListItemIcon>
+                <ListItemText
+                  primary={controller.service.repository}
+                  secondary="Repository"
+                />
+              </ListItem>
+            )}
+
+            {controller.service.taskBoard !== undefined && (
+              <ListItem divider>
+                <ListItemIcon>
+                  <TaskAlt />
+                </ListItemIcon>
+                <ListItemText
+                  primary={controller.service.taskBoard}
+                  secondary="Task Board"
+                />
+              </ListItem>
+            )}
+          </List>
+        </Box>
+      )}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
This PR removes `JSON.stringify()` from the Service Details page. Instead, we now show some basic information about a service: The name, group, repository, and task board.

Please note that this only affects the Service Details page. On the Group Detail page, we are still showing the `JSON.stringify()` content.

# Screenshots
![grafik](https://user-images.githubusercontent.com/8061217/193045907-97ee49b7-a82f-4d03-875e-9a704930f911.png)

If a particular piece of information is not available, it will simply not be shown in the list (here, the group is missing):
![grafik](https://user-images.githubusercontent.com/8061217/193046029-ea7c442b-8a12-4f6d-9a45-e0ab5ec206d6.png)
