### PR TITLE
Service dependencies

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
@@ -13,14 +13,12 @@ import {
   Typography,
 } from '@mui/material';
 import React from 'react';
-import { useMatch } from 'react-router-dom';
 
-import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
-import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+import { useSelectedTreeItem } from '../../utils/router-utils';
 import {
-  ServiceDocsGroup,
-  ServiceDocsRootGroup,
-  getGroupByIdentifier,
+  ServiceDocsRegularGroupTreeItem,
+  ServiceDocsRootTreeItem,
+  ServiceDocsTreeItemType,
 } from '../../utils/service-docs-utils';
 
 export const GroupDetails: React.FC = () => {
@@ -28,7 +26,7 @@ export const GroupDetails: React.FC = () => {
 
   return (
     <React.Fragment>
-      {controller.groupWithType !== undefined && (
+      {controller.group !== undefined && (
         <Box
           sx={{
             overflowX: 'hidden',
@@ -39,28 +37,30 @@ export const GroupDetails: React.FC = () => {
         >
           <Typography variant="h3">Group Information</Typography>
 
-          {controller.groupWithType.type === 'regular-group' && (
+          {controller.group.treeItemType ===
+            ServiceDocsTreeItemType.RegularGroup && (
             <List>
               <ListItem divider>
                 <ListItemIcon>
                   <Badge />
                 </ListItemIcon>
                 <ListItemText
-                  primary={controller.groupWithType.group.name}
+                  primary={controller.group.name}
                   secondary="Name"
                 />
               </ListItem>
             </List>
           )}
 
-          {controller.groupWithType.type === 'regular-group' && (
+          {controller.group.treeItemType ===
+            ServiceDocsTreeItemType.RegularGroup && (
             <List>
               <ListItem divider>
                 <ListItemIcon>
                   <Group />
                 </ListItemIcon>
                 <ListItemText
-                  primary={controller.groupWithType.group.identifier}
+                  primary={controller.group.identifier}
                   secondary="Full identifier"
                 />
               </ListItem>
@@ -73,8 +73,8 @@ export const GroupDetails: React.FC = () => {
                 <CenterFocusStrongOutlined />
               </ListItemIcon>
               <ListItemText
-                primary={`${controller.groupWithType.group.services.length} ${
-                  controller.groupWithType.group.services.length === 1
+                primary={`${controller.group.services.length} ${
+                  controller.group.services.length === 1
                     ? 'Service'
                     : 'Services'
                 }`}
@@ -89,11 +89,8 @@ export const GroupDetails: React.FC = () => {
                 <DatasetOutlined />
               </ListItemIcon>
               <ListItemText
-                primary={`${
-                  Object.keys(controller.groupWithType.group.childGroups).length
-                } ${
-                  Object.keys(controller.groupWithType.group.childGroups)
-                    .length === 1
+                primary={`${Object.keys(controller.group.childGroups).length} ${
+                  Object.keys(controller.group.childGroups).length === 1
                     ? 'Group'
                     : 'Groups'
                 }`}
@@ -107,46 +104,25 @@ export const GroupDetails: React.FC = () => {
   );
 };
 
-type GroupWithType = RootGroupWithType | RegularGroupWithType;
-interface RootGroupWithType {
-  type: 'root-group';
-  group: ServiceDocsRootGroup;
-}
-interface RegularGroupWithType {
-  type: 'regular-group';
-  group: ServiceDocsGroup;
-}
-
 interface Controller {
-  groupWithType: GroupWithType | undefined;
+  group: ServiceDocsRegularGroupTreeItem | ServiceDocsRootTreeItem | undefined;
 }
-
 function useController(): Controller {
-  const groupRouterMatch = useMatch(GROUPS_TREE_ROUTES_ABS.group);
-  const rootRouterMatch = useMatch(GROUPS_TREE_ROUTES_ABS.root);
-  const serviceDocsService = useServiceDocsServiceContext();
+  const selectedTreeItem = useSelectedTreeItem();
 
-  const groupWithType = React.useMemo((): GroupWithType | undefined => {
-    if (groupRouterMatch && groupRouterMatch.params.group !== undefined) {
-      const theGroup = getGroupByIdentifier(
-        groupRouterMatch.params.group,
-        serviceDocsService.groupsTree,
-      );
-      if (!theGroup) {
-        return undefined;
-      }
-      return { type: 'regular-group', group: theGroup };
-    }
+  let group:
+    | ServiceDocsRegularGroupTreeItem
+    | ServiceDocsRootTreeItem
+    | undefined = undefined;
+  if (
+    selectedTreeItem &&
+    (selectedTreeItem.treeItemType === ServiceDocsTreeItemType.RootGroup ||
+      selectedTreeItem.treeItemType === ServiceDocsTreeItemType.RegularGroup)
+  ) {
+    group = selectedTreeItem;
+  }
 
-    if (rootRouterMatch) {
-      return { type: 'root-group', group: serviceDocsService.groupsTree };
-    }
-
-    console.warn(
-      'Neither the group route nor the root route matched. This should not happen.',
-    );
-    return undefined;
-  }, [groupRouterMatch, rootRouterMatch, serviceDocsService.groupsTree]);
-
-  return { groupWithType: groupWithType };
+  return {
+    group: group,
+  };
 }

--- a/frontend/src/components/main-page/groups-tree-page/service-details/dependencies.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/dependencies.tsx
@@ -1,0 +1,186 @@
+import {
+  ArchiveOutlined,
+  CloudDownloadOutlined,
+  CloudUploadOutlined,
+  UnarchiveOutlined,
+} from '@mui/icons-material';
+import {
+  Alert,
+  Card,
+  CardContent,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import { generatePath, useNavigate } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
+import { ServiceDocsServiceTreeItem } from '../../utils/service-docs-utils';
+
+import { DependencyDetails } from './dependency-details';
+
+interface Props {
+  service: ServiceDocsServiceTreeItem;
+}
+export const Dependencies: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <React.Fragment>
+      <Typography variant="h3">Dependencies</Typography>
+
+      {controller.dependencyItems.map((dependencyItem) => (
+        <Card key={dependencyItem.type} sx={{ marginTop: 3 }}>
+          <CardContent>
+            <Typography variant="h5" component="div" sx={{ marginBottom: 2 }}>
+              {dependencyItem.type === 'provided-apis' && 'Provided APIs'}
+              {dependencyItem.type === 'consumed-apis' && 'Consumed APIs'}
+              {dependencyItem.type === 'produced-events' && 'Produced Events'}
+              {dependencyItem.type === 'consumed-events' && 'Consumed Events'}
+            </Typography>
+
+            {dependencyItem.data.length < 1 && (
+              <Alert severity="info">
+                {dependencyItem.type === 'provided-apis' && 'No provided APIs'}
+                {dependencyItem.type === 'consumed-apis' && 'No consumed APIs'}
+                {dependencyItem.type === 'produced-events' &&
+                  'No produced Events'}
+                {dependencyItem.type === 'consumed-events' &&
+                  'No consumed Events'}
+              </Alert>
+            )}
+
+            {dependencyItem.data.length > 0 && (
+              <List component="div">
+                {dependencyItem.data.map((apiOrEventName) => (
+                  <ListItemButton
+                    key={apiOrEventName}
+                    onClick={(): void =>
+                      controller.showDependencyDialog({
+                        dependencyType: dependencyItem.type,
+                        itemName: apiOrEventName,
+                      })
+                    }
+                  >
+                    <ListItemIcon>
+                      {dependencyItem.type === 'provided-apis' && (
+                        <CloudUploadOutlined />
+                      )}
+                      {dependencyItem.type === 'consumed-apis' && (
+                        <CloudDownloadOutlined />
+                      )}
+                      {dependencyItem.type === 'produced-events' && (
+                        <UnarchiveOutlined />
+                      )}
+                      {dependencyItem.type === 'consumed-events' && (
+                        <ArchiveOutlined />
+                      )}
+                    </ListItemIcon>
+                    <ListItemText>{apiOrEventName}</ListItemText>
+                  </ListItemButton>
+                ))}
+              </List>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+
+      {controller.state.dependencyDialogData && (
+        <DependencyDetails
+          dependencyType={
+            controller.state.dependencyDialogData.dependencyType ===
+              'provided-apis' ||
+            controller.state.dependencyDialogData.dependencyType ===
+              'consumed-apis'
+              ? 'api'
+              : 'event'
+          }
+          dependencyName={controller.state.dependencyDialogData.itemName}
+          currentService={props.service}
+          close={(): void => controller.hideDependencyDialog()}
+          goToService={(serviceName: string): void => {
+            controller.hideDependencyDialog();
+            controller.goToService(serviceName);
+          }}
+        />
+      )}
+    </React.Fragment>
+  );
+};
+
+type DependencyType =
+  | 'provided-apis'
+  | 'consumed-apis'
+  | 'produced-events'
+  | 'consumed-events';
+interface DependencyItem {
+  type: DependencyType;
+  data: string[];
+}
+
+interface DependencyDialogData {
+  dependencyType: DependencyType;
+  itemName: string;
+}
+
+interface State {
+  dependencyDialogData: DependencyDialogData | undefined;
+}
+interface Controller {
+  state: State;
+
+  dependencyItems: DependencyItem[];
+
+  showDependencyDialog: (data: DependencyDialogData) => void;
+  hideDependencyDialog: () => void;
+  goToService: (serviceName: string) => void;
+}
+function useController(props: Props): Controller {
+  const navigate = useNavigate();
+
+  const [state, setState] = React.useState<State>({
+    dependencyDialogData: undefined,
+  });
+
+  const dataToShow: DependencyItem[] = [
+    {
+      type: 'provided-apis',
+      data: props.service.providedAPIs ?? [],
+    },
+    {
+      type: 'consumed-apis',
+      data: props.service.consumedAPIs ?? [],
+    },
+    {
+      type: 'produced-events',
+      data: props.service.producedEvents ?? [],
+    },
+    {
+      type: 'consumed-events',
+      data: props.service.consumedEvents ?? [],
+    },
+  ];
+
+  return {
+    state: state,
+
+    dependencyItems: dataToShow,
+
+    showDependencyDialog: (data): void => {
+      setState((state) => ({ ...state, dependencyDialogData: data }));
+    },
+    hideDependencyDialog: (): void => {
+      setState((state) => ({ ...state, dependencyDialogData: undefined }));
+    },
+    goToService: (serviceName: string): void => {
+      navigate(
+        generatePath(GROUPS_TREE_ROUTES_ABS.service, {
+          service: serviceName,
+        }),
+      );
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/service-details/dependency-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/dependency-details.tsx
@@ -1,0 +1,157 @@
+import { CenterFocusStrongOutlined } from '@mui/icons-material';
+import {
+  Alert,
+  Dialog,
+  DialogContent,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+
+import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+import { ServiceDocsServiceTreeItem } from '../../utils/service-docs-utils';
+
+interface Props {
+  dependencyType: 'api' | 'event';
+  dependencyName: string;
+
+  currentService: ServiceDocsServiceTreeItem;
+
+  close: () => void;
+  goToService: (serviceName: string) => void;
+}
+export const DependencyDetails: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <Dialog open onClose={(): void => props.close()}>
+      <DialogContent sx={{ width: '500px' }}>
+        <Typography variant="h4" sx={{ overflowWrap: 'anywhere' }}>
+          {props.dependencyType === 'api' ? 'API Details' : 'Event Details'}
+        </Typography>
+
+        <Typography variant="subtitle1">
+          {props.dependencyType === 'api'
+            ? `API "${props.dependencyName}" has the following Providers and Consumers.`
+            : `Event "${props.dependencyName}" has the following Producers and Consumers.`}
+        </Typography>
+
+        {controller.detailsItems.map((detailsDataItem) => (
+          <React.Fragment key={detailsDataItem.type}>
+            <Typography variant="h5" sx={{ marginTop: 2 }}>
+              {detailsDataItem.type === 'providers-or-producers' &&
+                props.dependencyType === 'api' &&
+                'Providers'}
+              {detailsDataItem.type === 'providers-or-producers' &&
+                props.dependencyType === 'event' &&
+                'Producers'}
+              {detailsDataItem.type === 'consumers' && 'Consumers'}
+            </Typography>
+
+            {detailsDataItem.services.length < 1 && (
+              <Alert severity="info" sx={{ marginTop: 1 }}>
+                {detailsDataItem.type === 'providers-or-producers' &&
+                  props.dependencyType === 'api' &&
+                  'No Providers'}
+                {detailsDataItem.type === 'providers-or-producers' &&
+                  props.dependencyType === 'event' &&
+                  'No Producers'}
+                {detailsDataItem.type === 'consumers' && 'No Consumers'}
+              </Alert>
+            )}
+
+            {detailsDataItem.services.length > 0 && (
+              <List>
+                {detailsDataItem.services.map((service) => (
+                  <ListItemButton
+                    key={service.name}
+                    disabled={service.name === props.currentService.name}
+                    onClick={(): void => props.goToService(service.name)}
+                  >
+                    <ListItemIcon>
+                      <CenterFocusStrongOutlined />
+                    </ListItemIcon>
+                    <ListItemText>{service.name}</ListItemText>
+                  </ListItemButton>
+                ))}
+              </List>
+            )}
+          </React.Fragment>
+        ))}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface DetailsItem {
+  type: 'providers-or-producers' | 'consumers';
+  services: ServiceDocsServiceTreeItem[];
+}
+
+interface Controller {
+  detailsItems: DetailsItem[];
+}
+function useController(props: Props): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const [providingServices, consumingServices] = React.useMemo((): [
+    ServiceDocsServiceTreeItem[],
+    ServiceDocsServiceTreeItem[],
+  ] => {
+    const providingServices: ServiceDocsServiceTreeItem[] = [];
+    const consumingServices: ServiceDocsServiceTreeItem[] = [];
+
+    for (const singleService of serviceDocsService.serviceDocs) {
+      if (props.dependencyType === 'api') {
+        if (
+          singleService.providedAPIs &&
+          singleService.providedAPIs.includes(props.dependencyName)
+        ) {
+          providingServices.push(singleService);
+        }
+        if (
+          singleService.consumedAPIs &&
+          singleService.consumedAPIs.includes(props.dependencyName)
+        ) {
+          consumingServices.push(singleService);
+        }
+
+        continue;
+      }
+
+      if (
+        singleService.producedEvents &&
+        singleService.producedEvents.includes(props.dependencyName)
+      ) {
+        providingServices.push(singleService);
+      }
+      if (
+        singleService.consumedEvents &&
+        singleService.consumedEvents.includes(props.dependencyName)
+      ) {
+        consumingServices.push(singleService);
+      }
+    }
+
+    return [providingServices, consumingServices];
+  }, [
+    props.dependencyName,
+    props.dependencyType,
+    serviceDocsService.serviceDocs,
+  ]);
+
+  const detailsData: DetailsItem[] = [
+    {
+      type: 'providers-or-producers',
+      services: providingServices,
+    },
+    { type: 'consumers', services: consumingServices },
+  ];
+
+  return {
+    detailsItems: detailsData,
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -7,12 +7,13 @@ import {
   ListItemText,
   Typography,
 } from '@mui/material';
-import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
-import { useMatch } from 'react-router-dom';
 
-import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
-import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+import { useSelectedTreeItem } from '../../utils/router-utils';
+import {
+  ServiceDocsServiceTreeItem,
+  ServiceDocsTreeItemType,
+} from '../../utils/service-docs-utils';
 
 export const ServiceDetails: React.FC = () => {
   const controller = useController();
@@ -84,28 +85,18 @@ export const ServiceDetails: React.FC = () => {
 };
 
 interface Controller {
-  service: GetServiceDocResponse | undefined;
+  service: ServiceDocsServiceTreeItem | undefined;
 }
 function useController(): Controller {
-  const routerMatch = useMatch(GROUPS_TREE_ROUTES_ABS.service);
+  const selectedTreeItem = useSelectedTreeItem();
 
-  const serviceDocsService = useServiceDocsServiceContext();
-
-  const service = React.useMemo((): GetServiceDocResponse | undefined => {
-    if (!routerMatch || routerMatch.params.service === undefined) {
-      console.warn(
-        'The service route was not matched. This should not happen.',
-      );
-      return undefined;
-    }
-
-    return serviceDocsService.serviceDocs.find((item) => {
-      if (item.name !== routerMatch.params.service) {
-        return false;
-      }
-      return true;
-    });
-  }, [routerMatch, serviceDocsService.serviceDocs]);
+  let service: ServiceDocsServiceTreeItem | undefined = undefined;
+  if (
+    selectedTreeItem &&
+    selectedTreeItem.treeItemType === ServiceDocsTreeItemType.Service
+  ) {
+    service = selectedTreeItem;
+  }
 
   return {
     service: service,

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -15,6 +15,8 @@ import {
   ServiceDocsTreeItemType,
 } from '../../utils/service-docs-utils';
 
+import { Dependencies } from './dependencies';
+
 export const ServiceDetails: React.FC = () => {
   const controller = useController();
 
@@ -78,6 +80,10 @@ export const ServiceDetails: React.FC = () => {
               </ListItem>
             )}
           </List>
+
+          <Box sx={{ marginTop: 3 }}>
+            <Dependencies service={controller.service} />
+          </Box>
         </Box>
       )}
     </React.Fragment>

--- a/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
@@ -12,6 +12,7 @@ import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import {
   ServiceDocsRegularGroupTreeItem,
+  ServiceDocsTreeItem,
   ServiceDocsTreeItemType,
 } from '../../utils/service-docs-utils';
 
@@ -32,6 +33,7 @@ export const GroupItem: React.FC<Props> = (props) => {
   return (
     <React.Fragment>
       <ListItemButton
+        ref={controller.buttonRef}
         sx={{
           pl: props.depth * 4,
           background: (theme) =>
@@ -78,7 +80,7 @@ export const GroupItem: React.FC<Props> = (props) => {
 
       {!controller.state.isCollapsed && (
         <React.Fragment>
-          <List disablePadding>
+          <List component="div" disablePadding>
             {Object.values(props.group.childGroups).map((childGroup) => (
               <GroupItem
                 key={childGroup.identifier}
@@ -111,12 +113,16 @@ interface Controller {
 
   isSelected: boolean;
 
+  buttonRef: React.RefObject<HTMLDivElement>;
+
   navigateToThisGroup: () => void;
   toggleIsCollapsed: () => void;
 }
 function useController(props: Props): Controller {
   const navigate = useNavigate();
   const selectedTreeItem = useSelectedTreeItem();
+
+  const buttonRef = React.useRef<HTMLDivElement>(null);
 
   const [state, setState] = React.useState<State>({
     isCollapsed: true,
@@ -135,10 +141,32 @@ function useController(props: Props): Controller {
     return true;
   })();
 
+  // Whenever the item gets selected, scroll it into our viewport.
+  React.useEffect(() => {
+    if (!isSelected || !buttonRef.current) {
+      return;
+    }
+
+    buttonRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, [isSelected]);
+
+  // Automatically un-collapse this group if a child tree item gets selected using the Router.
+  React.useEffect(() => {
+    if (!selectedTreeItem) {
+      return;
+    }
+    if (!isXDescendantOfY({ x: selectedTreeItem, y: props.group })) {
+      return;
+    }
+    setState((state) => ({ ...state, isCollapsed: false }));
+  }, [props.group, selectedTreeItem]);
+
   return {
     state: state,
 
     isSelected: isSelected,
+
+    buttonRef: buttonRef,
 
     navigateToThisGroup: (): void => {
       navigate(
@@ -151,4 +179,75 @@ function useController(props: Props): Controller {
       setState((state) => ({ ...state, isCollapsed: !state.isCollapsed }));
     },
   };
+}
+
+/**
+ * Is `x` a descendant (i.e. child, or child of child, or ...) of `y`?
+ */
+function isXDescendantOfY(params: {
+  x: ServiceDocsTreeItem;
+  y: ServiceDocsTreeItem;
+}): boolean {
+  // The root group cannot be a child of anyone.
+  if (params.x.treeItemType === ServiceDocsTreeItemType.RootGroup) {
+    return false;
+  }
+
+  // A service cannot be the parent of anyone.
+  if (params.y.treeItemType === ServiceDocsTreeItemType.Service) {
+    return false;
+  }
+
+  // The root group is the parent of everyone.
+  if (params.y.treeItemType === ServiceDocsTreeItemType.RootGroup) {
+    return false;
+  }
+
+  if (params.x.treeItemType === ServiceDocsTreeItemType.Service) {
+    // A service with no group is only the descendant of the root group. But we have already covered the case where y=RootGroup before.
+    if (params.x.group === undefined) {
+      return false;
+    }
+
+    if (params.x.group === params.y.identifier) {
+      return true;
+    }
+    return isGroupXDescendantOfGroupY({
+      xIdentifier: params.x.group,
+      yIdentifier: params.y.identifier,
+    });
+  }
+
+  return isGroupXDescendantOfGroupY({
+    xIdentifier: params.y.identifier,
+    yIdentifier: params.y.identifier,
+  });
+}
+
+function isGroupXDescendantOfGroupY(params: {
+  xIdentifier: string;
+  yIdentifier: string;
+}): boolean {
+  /*  
+    A trick: We use the identifiers of the two groups in order to determine whether X is the descendant of Y.
+
+    Example: 
+    `XIdentifier`: "foo.bar.baz"
+    `YIdentifier`: "foo.bar"
+
+    Now, we simply check if `XIdentifier` starts with `YIdentifier`.
+
+    There is one edge case. Imagine the following:
+    `XIdentifier`: "foo.bars"
+    `YIdentifier`: "foo.bar"
+    Now, the check would return `true`, because `XIdentifier` starts with `YIdentifier`.
+    Because of this, we add a group delimiter (".") to `YIdentifier` before checking.
+  */
+
+  const yIdentifierForChecking = params.yIdentifier + '.';
+
+  if (params.xIdentifier.startsWith(yIdentifierForChecking)) {
+    return true;
+  }
+  return false;
 }

--- a/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
@@ -6,15 +6,19 @@ import {
   ListItemText,
 } from '@mui/material';
 import React from 'react';
-import { generatePath, useMatch, useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom';
 
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
-import { ServiceDocsGroup } from '../../utils/service-docs-utils';
+import { useSelectedTreeItem } from '../../utils/router-utils';
+import {
+  ServiceDocsRegularGroupTreeItem,
+  ServiceDocsTreeItemType,
+} from '../../utils/service-docs-utils';
 
 import { ServiceItem } from './service-item';
 
 interface Props {
-  group: ServiceDocsGroup;
+  group: ServiceDocsRegularGroupTreeItem;
 
   /**
    * How deep is this item in the tree?
@@ -112,17 +116,20 @@ interface Controller {
 }
 function useController(props: Props): Controller {
   const navigate = useNavigate();
-  const routeMatch = useMatch(GROUPS_TREE_ROUTES_ABS.group);
+  const selectedTreeItem = useSelectedTreeItem();
 
   const [state, setState] = React.useState<State>({
     isCollapsed: true,
   });
 
   const isSelected = ((): boolean => {
-    if (!routeMatch) {
+    if (
+      !selectedTreeItem ||
+      selectedTreeItem.treeItemType !== ServiceDocsTreeItemType.RegularGroup
+    ) {
       return false;
     }
-    if (routeMatch.params.group !== props.group.identifier) {
+    if (selectedTreeItem.identifier !== props.group.identifier) {
       return false;
     }
     return true;

--- a/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
@@ -1,16 +1,20 @@
 import { DatasetOutlined } from '@mui/icons-material';
 import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import React from 'react';
-import { useMatch, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
-import { ServiceDocsRootGroup } from '../../utils/service-docs-utils';
+import { useSelectedTreeItem } from '../../utils/router-utils';
+import {
+  ServiceDocsRootTreeItem,
+  ServiceDocsTreeItemType,
+} from '../../utils/service-docs-utils';
 
 import { GroupItem } from './group-item';
 import { ServiceItem } from './service-item';
 
 interface Props {
-  rootGroup: ServiceDocsRootGroup;
+  rootGroup: ServiceDocsRootTreeItem;
 }
 export const RootItem: React.FC<Props> = (props) => {
   const controller = useController();
@@ -60,10 +64,13 @@ interface Controller {
 }
 function useController(): Controller {
   const navigate = useNavigate();
-  const routeMatch = useMatch(GROUPS_TREE_ROUTES_ABS.root);
+  const selectedTreeItem = useSelectedTreeItem();
 
   const isSelected = ((): boolean => {
-    if (!routeMatch) {
+    if (
+      !selectedTreeItem ||
+      selectedTreeItem.treeItemType !== ServiceDocsTreeItemType.RootGroup
+    ) {
       return false;
     }
     return true;

--- a/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
@@ -22,6 +22,7 @@ export const RootItem: React.FC<Props> = (props) => {
   return (
     <React.Fragment>
       <ListItemButton
+        ref={controller.buttonRef}
         sx={{
           background: (theme) =>
             controller.isSelected ? theme.palette.primary.main : undefined,
@@ -60,11 +61,15 @@ export const RootItem: React.FC<Props> = (props) => {
 interface Controller {
   isSelected: boolean;
 
+  buttonRef: React.RefObject<HTMLDivElement>;
+
   navigateToRoot: () => void;
 }
 function useController(): Controller {
   const navigate = useNavigate();
   const selectedTreeItem = useSelectedTreeItem();
+
+  const buttonRef = React.useRef<HTMLDivElement>(null);
 
   const isSelected = ((): boolean => {
     if (
@@ -76,8 +81,19 @@ function useController(): Controller {
     return true;
   })();
 
+  // Whenever the item gets selected, scroll it into our viewport.
+  React.useEffect(() => {
+    if (!isSelected || !buttonRef.current) {
+      return;
+    }
+
+    buttonRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, [isSelected]);
+
   return {
     isSelected: isSelected,
+
+    buttonRef: buttonRef,
 
     navigateToRoot: (): void => {
       navigate(GROUPS_TREE_ROUTES_ABS.root);

--- a/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
@@ -22,6 +22,7 @@ export const ServiceItem: React.FC<Props> = (props) => {
 
   return (
     <ListItemButton
+      ref={controller.buttonRef}
       sx={{
         pl: props.depth * 4,
         background: (theme) =>
@@ -52,11 +53,15 @@ export const ServiceItem: React.FC<Props> = (props) => {
 interface Controller {
   isSelected: boolean;
 
+  buttonRef: React.RefObject<HTMLDivElement>;
+
   navigateToThisService: () => void;
 }
 function useController(props: Props): Controller {
   const navigate = useNavigate();
   const selectedTreeItem = useSelectedTreeItem();
+
+  const buttonRef = React.useRef<HTMLDivElement>(null);
 
   const isSelected = ((): boolean => {
     if (
@@ -71,8 +76,19 @@ function useController(props: Props): Controller {
     return true;
   })();
 
+  // Whenever the item gets selected, scroll it into our viewport.
+  React.useEffect(() => {
+    if (!isSelected || !buttonRef.current) {
+      return;
+    }
+
+    buttonRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, [isSelected]);
+
   return {
     isSelected: isSelected,
+
+    buttonRef: buttonRef,
 
     navigateToThisService: (): void => {
       navigate(

--- a/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
@@ -2,9 +2,11 @@ import { CenterFocusStrongOutlined } from '@mui/icons-material';
 import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
-import { generatePath, useMatch, useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom';
 
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
+import { useSelectedTreeItem } from '../../utils/router-utils';
+import { ServiceDocsTreeItemType } from '../../utils/service-docs-utils';
 
 interface Props {
   service: GetServiceDocResponse;
@@ -54,13 +56,16 @@ interface Controller {
 }
 function useController(props: Props): Controller {
   const navigate = useNavigate();
-  const routeMatch = useMatch(GROUPS_TREE_ROUTES_ABS.service);
+  const selectedTreeItem = useSelectedTreeItem();
 
   const isSelected = ((): boolean => {
-    if (!routeMatch) {
+    if (
+      !selectedTreeItem ||
+      selectedTreeItem.treeItemType !== ServiceDocsTreeItemType.Service
+    ) {
       return false;
     }
-    if (routeMatch.params.service !== props.service.name) {
+    if (selectedTreeItem.name !== props.service.name) {
       return false;
     }
     return true;

--- a/frontend/src/components/main-page/groups-tree-page/tree/tree.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/tree.tsx
@@ -2,7 +2,7 @@ import { List } from '@mui/material';
 import React from 'react';
 
 import { useServiceDocsServiceContext } from '../../services/service-docs-service';
-import { ServiceDocsRootGroup } from '../../utils/service-docs-utils';
+import { ServiceDocsRootTreeItem } from '../../utils/service-docs-utils';
 
 import { RootItem } from './root-item';
 
@@ -17,7 +17,7 @@ export const Tree: React.FC = () => {
 };
 
 interface Controller {
-  rootGroup: ServiceDocsRootGroup;
+  rootGroup: ServiceDocsRootTreeItem;
 }
 function useController(): Controller {
   const serviceDocsService = useServiceDocsServiceContext();

--- a/frontend/src/components/main-page/services/service-docs-service.tsx
+++ b/frontend/src/components/main-page/services/service-docs-service.tsx
@@ -2,24 +2,40 @@ import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
 
 import {
-  ServiceDocsRootGroup,
+  ServiceDocsRootTreeItem,
+  ServiceDocsServiceTreeItem,
+  ServiceDocsTreeItemType,
   buildGroupsTree,
 } from '../utils/service-docs-utils';
 
 interface ServiceDocsService {
-  serviceDocs: GetServiceDocResponse[];
-  groupsTree: ServiceDocsRootGroup;
+  serviceDocs: ServiceDocsServiceTreeItem[];
+  groupsTree: ServiceDocsRootTreeItem;
 }
 function useServiceDocsService(
   serviceDocs: GetServiceDocResponse[],
 ): ServiceDocsService {
+  const serviceDocsWithType =
+    React.useMemo((): ServiceDocsServiceTreeItem[] => {
+      const result: ServiceDocsServiceTreeItem[] = [];
+
+      for (const singleServiceDoc of serviceDocs) {
+        result.push({
+          ...singleServiceDoc,
+          treeItemType: ServiceDocsTreeItemType.Service,
+        });
+      }
+
+      return result;
+    }, [serviceDocs]);
+
   const groupsTree = React.useMemo(
-    (): ServiceDocsRootGroup => buildGroupsTree(serviceDocs),
-    [serviceDocs],
+    (): ServiceDocsRootTreeItem => buildGroupsTree(serviceDocsWithType),
+    [serviceDocsWithType],
   );
 
   return {
-    serviceDocs: serviceDocs,
+    serviceDocs: serviceDocsWithType,
     groupsTree: groupsTree,
   };
 }

--- a/frontend/src/components/main-page/utils/router-utils.ts
+++ b/frontend/src/components/main-page/utils/router-utils.ts
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useMatch } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../routes';
+import { useServiceDocsServiceContext } from '../services/service-docs-service';
+
+import {
+  ServiceDocsServiceTreeItem,
+  ServiceDocsTreeItem,
+  getGroupByIdentifier,
+} from './service-docs-utils';
+
+/**
+ * Get the selected Tree Item using the Router.
+ */
+export function useSelectedTreeItem(): ServiceDocsTreeItem | undefined {
+  const serviceRouterMatch = useMatch(GROUPS_TREE_ROUTES_ABS.service);
+  const groupRouterMatch = useMatch(GROUPS_TREE_ROUTES_ABS.group);
+  const rootRouterMatch = useMatch(GROUPS_TREE_ROUTES_ABS.root);
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const result = React.useMemo((): ServiceDocsTreeItem | undefined => {
+    if (serviceRouterMatch && serviceRouterMatch.params.service !== undefined) {
+      return getServiceByName(
+        serviceRouterMatch.params.service,
+        serviceDocsService.serviceDocs,
+      );
+    }
+
+    if (groupRouterMatch && groupRouterMatch.params.group !== undefined) {
+      return getGroupByIdentifier(
+        groupRouterMatch.params.group,
+        serviceDocsService.groupsTree,
+      );
+    }
+    if (rootRouterMatch) {
+      return serviceDocsService.groupsTree;
+    }
+    console.warn(
+      'The service, group, and root routes did not match. This should not happen.',
+    );
+    return undefined;
+  }, [
+    groupRouterMatch,
+    rootRouterMatch,
+    serviceDocsService.groupsTree,
+    serviceDocsService.serviceDocs,
+    serviceRouterMatch,
+  ]);
+
+  return result;
+}
+
+function getServiceByName(
+  serviceName: string,
+  allServices: ServiceDocsServiceTreeItem[],
+): ServiceDocsServiceTreeItem | undefined {
+  return allServices.find((item) => {
+    if (item.name === serviceName) {
+      return true;
+    }
+    return false;
+  });
+}

--- a/frontend/src/components/main-page/utils/service-docs-utils.ts
+++ b/frontend/src/components/main-page/utils/service-docs-utils.ts
@@ -1,6 +1,23 @@
 import { GetServiceDocResponse } from 'msadoc-client';
 
-export interface ServiceDocsGroup {
+export enum ServiceDocsTreeItemType {
+  Service,
+  RegularGroup,
+  RootGroup,
+}
+
+export type ServiceDocsTreeItem =
+  | ServiceDocsRootTreeItem
+  | ServiceDocsRegularGroupTreeItem
+  | ServiceDocsServiceTreeItem;
+
+export type ServiceDocsServiceTreeItem = GetServiceDocResponse & {
+  treeItemType: ServiceDocsTreeItemType.Service;
+};
+
+export interface ServiceDocsRegularGroupTreeItem {
+  treeItemType: ServiceDocsTreeItemType.RegularGroup;
+
   /**
    * The `name` of a group is the last part of its `identifier`.
    *
@@ -18,35 +35,43 @@ export interface ServiceDocsGroup {
    * The object keys are the names of the respective child group.
    * (Compared to just using an array, this enables a faster lookup of groups.)
    */
-  childGroups: { [groupName: string]: ServiceDocsGroup };
+  childGroups: { [groupName: string]: ServiceDocsRegularGroupTreeItem };
 
   /**
    * The services that belong to this group.
    */
-  services: GetServiceDocResponse[];
+  services: ServiceDocsServiceTreeItem[];
 }
-export type ServiceDocsRootGroup = Omit<
-  ServiceDocsGroup,
-  'name' | 'identifier'
->;
+// Basically the same as a regular group, but without a name or identifier.
+export type ServiceDocsRootTreeItem = Omit<
+  ServiceDocsRegularGroupTreeItem,
+  'name' | 'identifier' | 'treeItemType'
+> & {
+  treeItemType: ServiceDocsTreeItemType.RootGroup;
+};
 
 export function buildGroupsTree(
-  serviceDocs: GetServiceDocResponse[],
-): ServiceDocsRootGroup {
-  const rootGroup: ServiceDocsRootGroup = {
+  serviceDocs: ServiceDocsServiceTreeItem[],
+): ServiceDocsRootTreeItem {
+  const rootGroup: ServiceDocsRootTreeItem = {
+    treeItemType: ServiceDocsTreeItemType.RootGroup,
     childGroups: {},
     services: [],
   };
 
   for (const singleServiceDoc of serviceDocs) {
-    let group = rootGroup;
+    let group: ServiceDocsRootTreeItem | ServiceDocsRegularGroupTreeItem =
+      rootGroup;
 
     // By default, we add the service to the root group. But if the service has the `group` attribute, then we want to add it to this specified group instead.
     if (singleServiceDoc.group !== undefined) {
       group = addGroupIfNotExists(singleServiceDoc.group, rootGroup);
     }
 
-    group.services.push(singleServiceDoc);
+    group.services.push({
+      ...singleServiceDoc,
+      treeItemType: ServiceDocsTreeItemType.Service,
+    });
   }
 
   return rootGroup;
@@ -54,30 +79,33 @@ export function buildGroupsTree(
 
 export function getGroupByIdentifier(
   groupIdentifier: string,
-  groupsTree: ServiceDocsRootGroup,
-): ServiceDocsGroup | undefined {
+  groupsTree: ServiceDocsRootTreeItem,
+): ServiceDocsRegularGroupTreeItem | undefined {
   const splitGroupIdentifier = groupIdentifier.split('.');
-  let currentGroup = groupsTree;
+  let currentGroup: ServiceDocsRootTreeItem | ServiceDocsRegularGroupTreeItem =
+    groupsTree;
   for (const identifierPart of splitGroupIdentifier) {
-    const nextGroup = currentGroup.childGroups[identifierPart];
+    const nextGroup: ServiceDocsRegularGroupTreeItem | undefined =
+      currentGroup.childGroups[identifierPart];
     if (!nextGroup) {
       return undefined;
     }
     currentGroup = nextGroup;
   }
-  return currentGroup as ServiceDocsGroup;
+  return currentGroup as ServiceDocsRegularGroupTreeItem;
 }
 
 function addGroupIfNotExists(
   groupIdentifier: string,
-  rootGroup: ServiceDocsRootGroup,
-): ServiceDocsGroup | ServiceDocsRootGroup {
+  rootGroup: ServiceDocsRootTreeItem,
+): ServiceDocsRegularGroupTreeItem | ServiceDocsRootTreeItem {
   const splitGroupIdentifier = groupIdentifier.split('.');
   if (splitGroupIdentifier[0] === undefined) {
     console.warn('This point should not be reached.');
     return rootGroup;
   }
-  let currentGroup = rootGroup;
+  let currentGroup: ServiceDocsRootTreeItem | ServiceDocsRegularGroupTreeItem =
+    rootGroup;
   for (let i = 0; i < splitGroupIdentifier.length; i++) {
     const groupName = splitGroupIdentifier[i];
     if (groupName === undefined) {
@@ -85,10 +113,12 @@ function addGroupIfNotExists(
       continue;
     }
 
-    let childGroup = currentGroup.childGroups[groupName];
+    let childGroup: ServiceDocsRegularGroupTreeItem | undefined =
+      currentGroup.childGroups[groupName];
     if (!childGroup) {
       const identifier = splitGroupIdentifier.slice(0, i + 1).join('.');
       childGroup = {
+        treeItemType: ServiceDocsTreeItemType.RegularGroup,
         name: groupName,
         identifier: identifier,
         childGroups: {},


### PR DESCRIPTION
This PR contributes the following:
- There is now a hook function that allows us to easily fetch the currently selected Service/Group.
- When navigating to a new Service/Group, the items corresponding to the ancestors of the Service/Group in the tree are automatically un-collapsed. This is necessary when programmatically navigating e.g. because the user clicks on a Service in the main view.
- There is now a "Dependencies" section in the main view that lists all provided/consumed APIs and all produced/consumed Events. When a user clicks on an entry, a dialog is shown that shows all other Services that are related to the respective API or Event. When clicking on a Service in this list, the dialog closes and the new Service is selected, so that the user is now able to explore this Service in more detail. (That's why I added the automatic un-collapsing.)


# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/195979444-7005cf06-0e9b-4d40-b163-e733e5ead076.png)
![grafik](https://user-images.githubusercontent.com/8061217/195979451-1b45f03d-df99-4b8e-b70d-d2ed7f1d76ff.png)
![grafik](https://user-images.githubusercontent.com/8061217/195979453-4a77c420-84f2-4c35-9045-c7458c05b3c8.png)
![grafik](https://user-images.githubusercontent.com/8061217/195979473-d16d46b9-ab39-4ef9-92fe-98a22f43841f.png)
![grafik](https://user-images.githubusercontent.com/8061217/195979480-75853839-1304-4261-a3f2-b3de64578d60.png)
