### PR TITLE
Fix typos in examples

### DIFF
--- a/example/extraction.service.msadoc.json
+++ b/example/extraction.service.msadoc.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedApis": ["/extractions/config", "/extractions/execution-stats"],
+  "providedAPIs": ["/extractions/config", "/extractions/execution-stats"],
 
   "consumedEvents": ["extraction.execution.triggered"],
   "producedEvents": [

--- a/example/graphql-query.service.msadoc.json
+++ b/example/graphql-query.service.msadoc.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedApis": ["/query/graphql"],
+  "providedAPIs": ["/query/graphql"],
 
   "consumedEvents": [
     "loading.config.created",

--- a/example/load.service.msadoc.json
+++ b/example/load.service.msadoc.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedApis": ["/load/configs", "/load/execution-stats"],
+  "providedAPIs": ["/load/configs", "/load/execution-stats"],
 
   "producedEvents": [
     "load.config.created",

--- a/example/notification.service.msadoc.json
+++ b/example/notification.service.msadoc.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedApis": ["/notifications/configs", "/notifications/execution-stats"],
+  "providedAPIs": ["/notifications/configs", "/notifications/execution-stats"],
 
   "producedEvents": [
     "notification.config.created",

--- a/example/restful-query.service.msadoc.json
+++ b/example/restful-query.service.msadoc.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedApis": ["/query/restful"],
+  "providedAPIs": ["/query/restful"],
 
   "consumedEvents": [
     "loading.config.created",

--- a/example/scheduler.service.msadoc.json
+++ b/example/scheduler.service.msadoc.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedApis": ["/scheduler/tasks"],
+  "providedAPIs": ["/scheduler/tasks"],
 
   "producedEvents": ["extraction.execution.tiggered"],
   "consumedEvents": [

--- a/example/transformation.service.msadoc.json
+++ b/example/transformation.service.msadoc.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedApis": ["/transformation/configs", "transformation/execution-stats"],
+  "providedAPIs": ["/transformation/configs", "transformation/execution-stats"],
 
   "consumedEvents": [
     "extraction.config.created",

--- a/example/transformation.service.msadoc.json
+++ b/example/transformation.service.msadoc.json
@@ -6,7 +6,10 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "providedAPIs": ["/transformation/configs", "transformation/execution-stats"],
+  "providedAPIs": [
+    "/transformation/configs",
+    "/transformation/execution-stats"
+  ],
 
   "consumedEvents": [
     "extraction.config.created",

--- a/example/web.client.msadoc.json
+++ b/example/web.client.msadoc.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/jvalue/ods.git",
   "taskBoard": "https://github.com/jvalue/ods/projects",
 
-  "consumedApis": [
+  "consumedAPIs": [
     "/extractions/config",
     "/extractions/execution-stats",
 


### PR DESCRIPTION
When working on #51, I noticed a few typos in the examples:
- It said `providedApis` instead of `providedAPIs` (the same with consumed APIs)
- I noticed a missing slash in an API of the TransformationService. (That has no effect at the moment, but I still wanted to make the examples consistent, so I fixed this as well.)