### PR TITLE
Frontend token refreshing

### DIFF
--- a/frontend/src/components/main-page/utils/router-utils.ts
+++ b/frontend/src/components/main-page/utils/router-utils.ts
@@ -36,9 +36,6 @@ export function useSelectedTreeItem(): ServiceDocsTreeItem | undefined {
     if (rootRouterMatch) {
       return serviceDocsService.groupsTree;
     }
-    console.warn(
-      'The service, group, and root routes did not match. This should not happen.',
-    );
     return undefined;
   }, [
     groupRouterMatch,


### PR DESCRIPTION
This PR fixes token refreshing in the frontend. I initially thought that token refreshing was broken on the backend. But as it turns out, I should have had a closer look at the tests. 😄  The reason: The frontend currently only sends the refresh token in the body. But it seems like the refresh token needs to be sent both in the body and in the auth header. 

This PR fixes this by sending the refresh token both in the body and in the header.

Also, this PR removes a misleading `console.warn()` that would appear e.g. after logging in. Since this is such a small change, I decided to include it in this PR as well.