### PR TITLE
Improve DX by using a single 'Icons' variable

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -3,4 +3,23 @@ module.exports = {
   parserOptions: {
     tsconfigRootDir: __dirname,
   },
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: ['@mui/icons-material', '@mui/icons-material/*'],
+                message: `Use the 'Icons' export from 'src/icons.ts' instead.`,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
@@ -1,10 +1,4 @@
 import {
-  Badge,
-  CenterFocusStrongOutlined,
-  DatasetOutlined,
-  Group,
-} from '@mui/icons-material';
-import {
   Box,
   List,
   ListItem,
@@ -14,6 +8,7 @@ import {
 } from '@mui/material';
 import React from 'react';
 
+import { Icons } from '../../../../icons';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import {
   ServiceDocsRegularGroupTreeItem,
@@ -42,7 +37,7 @@ export const GroupDetails: React.FC = () => {
             <List>
               <ListItem divider>
                 <ListItemIcon>
-                  <Badge />
+                  <Icons.Badge />
                 </ListItemIcon>
                 <ListItemText
                   primary={controller.group.name}
@@ -57,7 +52,7 @@ export const GroupDetails: React.FC = () => {
             <List>
               <ListItem divider>
                 <ListItemIcon>
-                  <Group />
+                  <Icons.Group />
                 </ListItemIcon>
                 <ListItemText
                   primary={controller.group.identifier}
@@ -70,7 +65,7 @@ export const GroupDetails: React.FC = () => {
           <List>
             <ListItem divider>
               <ListItemIcon sx={{ color: 'inherit' }}>
-                <CenterFocusStrongOutlined />
+                <Icons.CenterFocusStrongOutlined />
               </ListItemIcon>
               <ListItemText
                 primary={`${controller.group.services.length} ${
@@ -86,7 +81,7 @@ export const GroupDetails: React.FC = () => {
           <List>
             <ListItem divider>
               <ListItemIcon sx={{ color: 'inherit' }}>
-                <DatasetOutlined />
+                <Icons.DatasetOutlined />
               </ListItemIcon>
               <ListItemText
                 primary={`${Object.keys(controller.group.childGroups).length} ${

--- a/frontend/src/components/main-page/groups-tree-page/service-details/dependencies.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/dependencies.tsx
@@ -1,10 +1,4 @@
 import {
-  ArchiveOutlined,
-  CloudDownloadOutlined,
-  CloudUploadOutlined,
-  UnarchiveOutlined,
-} from '@mui/icons-material';
-import {
   Alert,
   Card,
   CardContent,
@@ -17,6 +11,7 @@ import {
 import React from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
+import { Icons } from '../../../../icons';
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
 import { ServiceDocsServiceTreeItem } from '../../utils/service-docs-utils';
 
@@ -67,16 +62,16 @@ export const Dependencies: React.FC<Props> = (props) => {
                   >
                     <ListItemIcon>
                       {dependencyItem.type === 'provided-apis' && (
-                        <CloudUploadOutlined />
+                        <Icons.CloudUploadOutlined />
                       )}
                       {dependencyItem.type === 'consumed-apis' && (
-                        <CloudDownloadOutlined />
+                        <Icons.CloudDownloadOutlined />
                       )}
                       {dependencyItem.type === 'produced-events' && (
-                        <UnarchiveOutlined />
+                        <Icons.UnarchiveOutlined />
                       )}
                       {dependencyItem.type === 'consumed-events' && (
-                        <ArchiveOutlined />
+                        <Icons.ArchiveOutlined />
                       )}
                     </ListItemIcon>
                     <ListItemText>{apiOrEventName}</ListItemText>

--- a/frontend/src/components/main-page/groups-tree-page/service-details/dependency-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/dependency-details.tsx
@@ -1,4 +1,3 @@
-import { CenterFocusStrongOutlined } from '@mui/icons-material';
 import {
   Alert,
   Dialog,
@@ -11,6 +10,7 @@ import {
 } from '@mui/material';
 import React from 'react';
 
+import { Icons } from '../../../../icons';
 import { useServiceDocsServiceContext } from '../../services/service-docs-service';
 import { ServiceDocsServiceTreeItem } from '../../utils/service-docs-utils';
 
@@ -72,7 +72,7 @@ export const DependencyDetails: React.FC<Props> = (props) => {
                     onClick={(): void => props.goToService(service.name)}
                   >
                     <ListItemIcon>
-                      <CenterFocusStrongOutlined />
+                      <Icons.CenterFocusStrongOutlined />
                     </ListItemIcon>
                     <ListItemText>{service.name}</ListItemText>
                   </ListItemButton>

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -1,4 +1,3 @@
-import { Badge, Code, Group, TaskAlt } from '@mui/icons-material';
 import {
   Box,
   List,
@@ -9,6 +8,7 @@ import {
 } from '@mui/material';
 import React from 'react';
 
+import { Icons } from '../../../../icons';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import {
   ServiceDocsServiceTreeItem,
@@ -36,7 +36,7 @@ export const ServiceDetails: React.FC = () => {
           <List>
             <ListItem divider>
               <ListItemIcon>
-                <Badge />
+                <Icons.Badge />
               </ListItemIcon>
               <ListItemText
                 primary={controller.service.name}
@@ -47,7 +47,7 @@ export const ServiceDetails: React.FC = () => {
             {controller.service.group !== undefined && (
               <ListItem divider>
                 <ListItemIcon>
-                  <Group />
+                  <Icons.Group />
                 </ListItemIcon>
                 <ListItemText
                   primary={controller.service.group}
@@ -59,7 +59,7 @@ export const ServiceDetails: React.FC = () => {
             {controller.service.repository !== undefined && (
               <ListItem divider>
                 <ListItemIcon>
-                  <Code />
+                  <Icons.Code />
                 </ListItemIcon>
                 <ListItemText
                   primary={controller.service.repository}
@@ -71,7 +71,7 @@ export const ServiceDetails: React.FC = () => {
             {controller.service.taskBoard !== undefined && (
               <ListItem divider>
                 <ListItemIcon>
-                  <TaskAlt />
+                  <Icons.TaskAlt />
                 </ListItemIcon>
                 <ListItemText
                   primary={controller.service.taskBoard}

--- a/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
@@ -1,4 +1,3 @@
-import { ChevronRight, ExpandMore } from '@mui/icons-material';
 import {
   List,
   ListItemButton,
@@ -8,6 +7,7 @@ import {
 import React from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
+import { Icons } from '../../../../icons';
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import {
@@ -73,7 +73,11 @@ export const GroupItem: React.FC<Props> = (props) => {
             controller.toggleIsCollapsed();
           }}
         >
-          {controller.state.isCollapsed ? <ChevronRight /> : <ExpandMore />}
+          {controller.state.isCollapsed ? (
+            <Icons.ChevronRight />
+          ) : (
+            <Icons.ExpandMore />
+          )}
         </ListItemIcon>
         <ListItemText primary={props.group.name} />
       </ListItemButton>

--- a/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
@@ -1,8 +1,8 @@
-import { DatasetOutlined } from '@mui/icons-material';
 import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { Icons } from '../../../../icons';
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import {
@@ -42,7 +42,7 @@ export const RootItem: React.FC<Props> = (props) => {
         onClick={(): void => controller.navigateToRoot()}
       >
         <ListItemIcon sx={{ color: 'inherit' }}>
-          <DatasetOutlined />
+          <Icons.DatasetOutlined />
         </ListItemIcon>
         <ListItemText primary="Root" />
       </ListItemButton>

--- a/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
@@ -1,9 +1,9 @@
-import { CenterFocusStrongOutlined } from '@mui/icons-material';
 import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
+import { Icons } from '../../../../icons';
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../routes';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import { ServiceDocsTreeItemType } from '../../utils/service-docs-utils';
@@ -43,7 +43,7 @@ export const ServiceItem: React.FC<Props> = (props) => {
       onClick={(): void => controller.navigateToThisService()}
     >
       <ListItemIcon sx={{ color: 'inherit' }}>
-        <CenterFocusStrongOutlined />
+        <Icons.CenterFocusStrongOutlined />
       </ListItemIcon>
       <ListItemText primary={props.service.name} />
     </ListItemButton>

--- a/frontend/src/components/main-page/left-menu.tsx
+++ b/frontend/src/components/main-page/left-menu.tsx
@@ -1,8 +1,8 @@
-import { AccountTree, Key, Logout, Refresh } from '@mui/icons-material';
 import { Box, IconButton, Stack, Tooltip } from '@mui/material';
 import React from 'react';
 import { useMatch, useNavigate, useResolvedPath } from 'react-router-dom';
 
+import { Icons } from '../../icons';
 import { MAIN_PAGE_ROUTES_ABS } from '../../routes';
 import { useAuthDataServiceContext } from '../../services/auth-data-service';
 
@@ -27,14 +27,14 @@ export const LeftMenu: React.FC<Props> = (props) => {
           routerTarget={MAIN_PAGE_ROUTES_ABS.groupsTree}
           tooltipText="Groups Tree"
         >
-          <AccountTree fontSize="inherit" />
+          <Icons.AccountTree fontSize="inherit" />
         </NavButtonWithRouterTarget>
 
         <NavButtonWithRouterTarget
           routerTarget={MAIN_PAGE_ROUTES_ABS.authTokens}
           tooltipText="Auth Tokens"
         >
-          <Key fontSize="inherit" />
+          <Icons.Key fontSize="inherit" />
         </NavButtonWithRouterTarget>
       </Stack>
 
@@ -44,14 +44,14 @@ export const LeftMenu: React.FC<Props> = (props) => {
             tooltipText="Reload Service Docs"
             onClick={(): void => props.reloadServiceDocs()}
           >
-            <Refresh fontSize="inherit" />
+            <Icons.Refresh fontSize="inherit" />
           </NavButton>
 
           <NavButton
             tooltipText="Logout"
             onClick={(): void => controller.performLogout()}
           >
-            <Logout fontSize="inherit" />
+            <Icons.Logout fontSize="inherit" />
           </NavButton>
         </Stack>
       </Box>

--- a/frontend/src/icons.ts
+++ b/frontend/src/icons.ts
@@ -1,0 +1,8 @@
+/*
+  Some icons of MUI have names that collide with other built-in components.
+  An example is "Badge", which is both an icon and a MUI component.
+
+  To solve this, we import all icons into a variable and from now on, only use icons from this new variable. For instance, to use the "Badge" icon, we now write `<Icons.Badge />`.
+*/
+// eslint-disable-next-line no-restricted-imports
+export * as Icons from '@mui/icons-material';


### PR DESCRIPTION
This PR improves DX by creating a "namespace" (actually just a variable) for all icons.

Originally, we would use icons like so:

``` tsx
import { Badge } from '@mui/icons-material';

export const MyComponent: React.FC = () => {
  return <Badge />
}
```

Now, icons are used like this:


``` tsx
import { Icons } from '../icons';

export const MyComponent: React.FC = () => {
  return <Icons.Badge />
}
```

There is now also a linter rule that prevents imports from `@mui/icons-material` and all sub-packages.

### Rationale

Originally, we had many name collisions between icons and other MUI components. For instance, there is a "Badge" icon and a "Badge" MUI component. This is of course not ideal for DX. There are multiple ways to solve this:

1. Whenever we want to use a new icon, we import it from the default export:
 `import BadgeIcon from '@mui/icons-material/Badge'`
2. We could create a file like `icons.ts`, where we manually import and export every icon that is used somewhere in our application:
`export { Badge } from '@mui/icons-material'`
3. We could use a similar approach as 2., but simply export everything into one variable: 
`export * as Icons from '@mui/icons-material'`

The problem with option 1 is that it actually does not really contribute to DX. Because now, we need to create lots and lots of import statements where we have to manually define the icon names. Option 2 is a bit better, but this time, we need to keep track of all of the icons that are being used in the application. And, we need to (manually?) build this large `icons.ts` file.

I decided to go for option 3, because it does not have any of the issues of the first two options. I was initially worried about bundle size, but (at least in a very quick test of mine that might also be inaccurate), it seemed like Webpack was actually able to tree-shake this.

