### PR TITLE
Use custom decorators to aggregate multiple annotations

### DIFF
--- a/server/src/api-keys/api-keys.dto.ts
+++ b/server/src/api-keys/api-keys.dto.ts
@@ -1,10 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNonEmptyString } from '../utils/class-validators';
 
 export class CreateApiKeyRequestDto {
   @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
+  @IsNonEmptyString()
   keyName: string;
 }
 

--- a/server/src/service-docs/service-doc.dto.ts
+++ b/server/src/service-docs/service-doc.dto.ts
@@ -1,12 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsNonEmptyString,
+  IsNonEmptyStringArray,
+} from '../utils/class-validators';
 
 export class CreateServiceDocRequest {
   @ApiProperty({
     description: 'Name of the service. Used as identifier.',
   })
-  @IsString()
-  @IsNotEmpty()
+  @IsNonEmptyString()
   name: string;
 
   @ApiProperty({
@@ -14,37 +16,28 @@ export class CreateServiceDocRequest {
       'Name of the group. Used as identifier to match with group meta-data. Hierarchical groups separated by a dot, e.g. "group.sub-group.sub-sub-group"',
     required: false,
   })
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
+  @IsNonEmptyString({ isOptional: true })
   group?: string;
 
   @ApiProperty({
     description: 'List of tags used to filter.',
     required: false,
   })
-  @IsArray()
-  @IsOptional()
-  @IsString({ each: true })
-  @IsNotEmpty({ each: true })
+  @IsNonEmptyStringArray({ isOptional: true })
   tags?: string[];
 
   @ApiProperty({
     description: 'URL to code repository.',
     required: false,
   })
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
+  @IsNonEmptyString({ isOptional: true })
   repository?: string;
 
   @ApiProperty({
     description: 'URL to task board.',
     required: false,
   })
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
+  @IsNonEmptyString({ isOptional: true })
   taskBoard?: string;
 
   /** Dependencies */
@@ -54,10 +47,7 @@ export class CreateServiceDocRequest {
       'List of consumed API identifiers. API identifier matched for dependency analysis.',
     required: false,
   })
-  @IsArray()
-  @IsOptional()
-  @IsString({ each: true })
-  @IsNotEmpty({ each: true })
+  @IsNonEmptyStringArray({ isOptional: true })
   consumedAPIs?: string[];
 
   @ApiProperty({
@@ -65,10 +55,7 @@ export class CreateServiceDocRequest {
       'List of provided API identifiers. API identifier matched for dependency analysis.',
     required: false,
   })
-  @IsArray()
-  @IsOptional()
-  @IsString({ each: true })
-  @IsNotEmpty({ each: true })
+  @IsNonEmptyStringArray({ isOptional: true })
   providedAPIs?: string[];
 
   @ApiProperty({
@@ -76,10 +63,7 @@ export class CreateServiceDocRequest {
       'List of produced event identifiers. Event identifier matched for dependency analysis.',
     required: false,
   })
-  @IsArray()
-  @IsOptional()
-  @IsString({ each: true })
-  @IsNotEmpty({ each: true })
+  @IsNonEmptyStringArray({ isOptional: true })
   producedEvents?: string[];
 
   @ApiProperty({
@@ -87,10 +71,7 @@ export class CreateServiceDocRequest {
       'List of consumed event identifiers. Event identifier matched for dependency analysis.',
     required: false,
   })
-  @IsArray()
-  @IsOptional()
-  @IsString({ each: true })
-  @IsNotEmpty({ each: true })
+  @IsNonEmptyStringArray({ isOptional: true })
   consumedEvents?: string[];
 
   /** Documentation links */
@@ -99,27 +80,21 @@ export class CreateServiceDocRequest {
     description: 'URL to development documentation.',
     required: false,
   })
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
+  @IsNonEmptyString({ isOptional: true })
   developmentDocumentation?: string;
 
   @ApiProperty({
     description: 'URL to deployment documentation.',
     required: false,
   })
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
+  @IsNonEmptyString({ isOptional: true })
   deploymentDocumentation?: string;
 
   @ApiProperty({
     description: 'URL to API documentation.',
     required: false,
   })
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
+  @IsNonEmptyString({ isOptional: true })
   apiDocumentation?: string;
 
   /** Responsibilities */
@@ -129,19 +104,14 @@ export class CreateServiceDocRequest {
       'Responsible team identifier. Used for matching multiple services to teams',
     required: false,
   })
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
+  @IsNonEmptyString({ isOptional: true })
   responsibleTeam?: string;
 
   @ApiProperty({
     description: 'List of responsible person identifiers.',
     required: false,
   })
-  @IsArray()
-  @IsOptional()
-  @IsString({ each: true })
-  @IsNotEmpty({ each: true })
+  @IsNonEmptyStringArray({ isOptional: true })
   responsibles?: string[];
 }
 

--- a/server/src/service-docs/service-doc.dto.ts
+++ b/server/src/service-docs/service-doc.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  IsNonEmptyOptionalString,
+  IsNonEmptyOptionalStringArray,
   IsNonEmptyString,
-  IsNonEmptyStringArray,
 } from '../utils/class-validators';
 
 export class CreateServiceDocRequest {
@@ -16,28 +17,28 @@ export class CreateServiceDocRequest {
       'Name of the group. Used as identifier to match with group meta-data. Hierarchical groups separated by a dot, e.g. "group.sub-group.sub-sub-group"',
     required: false,
   })
-  @IsNonEmptyString({ isOptional: true })
+  @IsNonEmptyOptionalString()
   group?: string;
 
   @ApiProperty({
     description: 'List of tags used to filter.',
     required: false,
   })
-  @IsNonEmptyStringArray({ isOptional: true })
+  @IsNonEmptyOptionalStringArray()
   tags?: string[];
 
   @ApiProperty({
     description: 'URL to code repository.',
     required: false,
   })
-  @IsNonEmptyString({ isOptional: true })
+  @IsNonEmptyOptionalString()
   repository?: string;
 
   @ApiProperty({
     description: 'URL to task board.',
     required: false,
   })
-  @IsNonEmptyString({ isOptional: true })
+  @IsNonEmptyOptionalString()
   taskBoard?: string;
 
   /** Dependencies */
@@ -47,7 +48,7 @@ export class CreateServiceDocRequest {
       'List of consumed API identifiers. API identifier matched for dependency analysis.',
     required: false,
   })
-  @IsNonEmptyStringArray({ isOptional: true })
+  @IsNonEmptyOptionalStringArray()
   consumedAPIs?: string[];
 
   @ApiProperty({
@@ -55,7 +56,7 @@ export class CreateServiceDocRequest {
       'List of provided API identifiers. API identifier matched for dependency analysis.',
     required: false,
   })
-  @IsNonEmptyStringArray({ isOptional: true })
+  @IsNonEmptyOptionalStringArray()
   providedAPIs?: string[];
 
   @ApiProperty({
@@ -63,7 +64,7 @@ export class CreateServiceDocRequest {
       'List of produced event identifiers. Event identifier matched for dependency analysis.',
     required: false,
   })
-  @IsNonEmptyStringArray({ isOptional: true })
+  @IsNonEmptyOptionalStringArray()
   producedEvents?: string[];
 
   @ApiProperty({
@@ -71,7 +72,7 @@ export class CreateServiceDocRequest {
       'List of consumed event identifiers. Event identifier matched for dependency analysis.',
     required: false,
   })
-  @IsNonEmptyStringArray({ isOptional: true })
+  @IsNonEmptyOptionalStringArray()
   consumedEvents?: string[];
 
   /** Documentation links */
@@ -80,21 +81,21 @@ export class CreateServiceDocRequest {
     description: 'URL to development documentation.',
     required: false,
   })
-  @IsNonEmptyString({ isOptional: true })
+  @IsNonEmptyOptionalString()
   developmentDocumentation?: string;
 
   @ApiProperty({
     description: 'URL to deployment documentation.',
     required: false,
   })
-  @IsNonEmptyString({ isOptional: true })
+  @IsNonEmptyOptionalString()
   deploymentDocumentation?: string;
 
   @ApiProperty({
     description: 'URL to API documentation.',
     required: false,
   })
-  @IsNonEmptyString({ isOptional: true })
+  @IsNonEmptyOptionalString()
   apiDocumentation?: string;
 
   /** Responsibilities */
@@ -104,14 +105,14 @@ export class CreateServiceDocRequest {
       'Responsible team identifier. Used for matching multiple services to teams',
     required: false,
   })
-  @IsNonEmptyString({ isOptional: true })
+  @IsNonEmptyOptionalString()
   responsibleTeam?: string;
 
   @ApiProperty({
     description: 'List of responsible person identifiers.',
     required: false,
   })
-  @IsNonEmptyStringArray({ isOptional: true })
+  @IsNonEmptyOptionalStringArray()
   responsibles?: string[];
 }
 

--- a/server/src/utils/class-validators.ts
+++ b/server/src/utils/class-validators.ts
@@ -1,39 +1,82 @@
 import { IsString, IsNotEmpty, IsOptional, IsArray } from 'class-validator';
 
+type FilterByValueType<Container, ExpectedType> = {
+  [Key in keyof Container]: Container[Key] extends ExpectedType ? Key : never;
+}[keyof Container];
+
+type FilterByOptionalKeys<Container> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [Key in keyof Container]: {} extends Pick<Container, Key> ? Key : never;
+}[keyof Container];
+
 /**
- * Combines class-validator decorators "@IsString", "@IsNotEmpty", and "@IsOptional" if configured
+ * Combines class-validator decorators "@IsString", and "@IsNotEmpty"
  */
-export function IsNonEmptyString(options?: {
-  isOptional?: boolean;
-}): PropertyDecorator {
+export function IsNonEmptyString() {
   const isStringFn = IsString();
   const isNotEmptyFn = IsNotEmpty();
-  const isOptionalFn = IsOptional();
-  return function (target: any, key: string) {
-    isStringFn(target, key);
-    isNotEmptyFn(target, key);
-    if (options?.isOptional === true) {
-      isOptionalFn(target, key);
-    }
+
+  return function IsNonEmptyString<T extends object>(
+    target: T,
+    key: FilterByValueType<T, string>,
+  ) {
+    isStringFn(target, key as any);
+    isNotEmptyFn(target, key as any);
   };
 }
 
 /**
- * Combines class-validator decorators "@IsArray", "@IsString", "@IsNotEmpty", and "@IsOptional" if configured
+ * Combines class-validator decorators "@IsString", "@IsNotEmpty", and "@IsOptional"
  */
-export function IsNonEmptyStringArray(options?: {
-  isOptional?: boolean;
-}): PropertyDecorator {
+export function IsNonEmptyOptionalString() {
+  const isStringFn = IsString();
+  const isNotEmptyFn = IsNotEmpty();
+  const isOptionalFn = IsOptional();
+
+  return function IsNonEmptyString<T extends object>(
+    target: T,
+    key: FilterByValueType<Required<T>, string> & FilterByOptionalKeys<T>,
+  ) {
+    isStringFn(target, key as any);
+    isNotEmptyFn(target, key as any);
+    isOptionalFn(target, key as any);
+  };
+}
+
+/**
+ * Combines class-validator decorators "@IsArray", "@IsString", and "@IsNotEmpty"
+ */
+export function IsNonEmptyStringArray() {
+  const isArrayFn = IsArray();
+  const isStringFn = IsString({ each: true });
+  const isNotEmptyFn = IsNotEmpty({ each: true });
+
+  return function IsNonEmptyString<T extends object>(
+    target: T,
+    key: FilterByValueType<T, string[]>,
+  ) {
+    isArrayFn(target, key as any);
+    isStringFn(target, key as any);
+    isNotEmptyFn(target, key as any);
+  };
+}
+
+/**
+ * Combines class-validator decorators "@IsArray", "@IsString", "@IsNotEmpty", and "IsOptional"
+ */
+export function IsNonEmptyOptionalStringArray() {
   const isArrayFn = IsArray();
   const isStringFn = IsString({ each: true });
   const isNotEmptyFn = IsNotEmpty({ each: true });
   const isOptionalFn = IsOptional();
-  return function (target: any, key: string) {
-    isArrayFn(target, key);
-    isStringFn(target, key);
-    isNotEmptyFn(target, key);
-    if (options?.isOptional === true) {
-      isOptionalFn(target, key);
-    }
+
+  return function IsNonEmptyString<T extends object>(
+    target: T,
+    key: FilterByValueType<Required<T>, string[]> & FilterByOptionalKeys<T>,
+  ) {
+    isArrayFn(target, key as any);
+    isStringFn(target, key as any);
+    isNotEmptyFn(target, key as any);
+    isOptionalFn(target, key as any);
   };
 }

--- a/server/src/utils/class-validators.ts
+++ b/server/src/utils/class-validators.ts
@@ -1,0 +1,39 @@
+import { IsString, IsNotEmpty, IsOptional, IsArray } from 'class-validator';
+
+/**
+ * Combines class-validator decorators "@IsString", "@IsNotEmpty", and "@IsOptional" if configured
+ */
+export function IsNonEmptyString(options?: {
+  isOptional?: boolean;
+}): PropertyDecorator {
+  const isStringFn = IsString();
+  const isNotEmptyFn = IsNotEmpty();
+  const isOptionalFn = IsOptional();
+  return function (target: any, key: string) {
+    isStringFn(target, key);
+    isNotEmptyFn(target, key);
+    if (options?.isOptional === true) {
+      isOptionalFn(target, key);
+    }
+  };
+}
+
+/**
+ * Combines class-validator decorators "@IsArray", "@IsString", "@IsNotEmpty", and "@IsOptional" if configured
+ */
+export function IsNonEmptyStringArray(options?: {
+  isOptional?: boolean;
+}): PropertyDecorator {
+  const isArrayFn = IsArray();
+  const isStringFn = IsString({ each: true });
+  const isNotEmptyFn = IsNotEmpty({ each: true });
+  const isOptionalFn = IsOptional();
+  return function (target: any, key: string) {
+    isArrayFn(target, key);
+    isStringFn(target, key);
+    isNotEmptyFn(target, key);
+    if (options?.isOptional === true) {
+      isOptionalFn(target, key);
+    }
+  };
+}

--- a/server/test/service-docs.e2e-spec.ts
+++ b/server/test/service-docs.e2e-spec.ts
@@ -82,7 +82,7 @@ describe('ServiceDocsController (e2e)', () => {
           .expect(400);
       });
 
-      it.each([
+      const optionalStringParameters = [
         'group',
         'repository',
         'taskBoard',
@@ -90,39 +90,149 @@ describe('ServiceDocsController (e2e)', () => {
         'deploymentDocumentation',
         'apiDocumentation',
         'responsibleTeam',
-      ])('no empty string in parameter %s', async (paramName: string) => {
-        const body: Record<string, string> = {
-          name: 'test',
-        };
-        body[paramName] = '';
+      ];
+      it.each(optionalStringParameters)(
+        'no empty string in string parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string> = {
+            name: 'test',
+          };
+          body[paramName] = '';
 
-        const accessToken = await getAccessToken();
-        await request(app.getHttpServer())
-          .post('/service-docs')
-          .auth(accessToken, { type: 'bearer' })
-          .send(body)
-          .expect(400);
-      });
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
 
-      it.each([
+      it.each(optionalStringParameters)(
+        'no number type in string parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string | number> = {
+            name: 'test',
+          };
+          body[paramName] = 123;
+
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
+
+      it.each(optionalStringParameters)(
+        'no object type in string parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string | object> = {
+            name: 'test',
+          };
+          body[paramName] = { test: 'test' };
+
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
+
+      it.each(optionalStringParameters)(
+        'no array type in string parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string | string[]> = {
+            name: 'test',
+          };
+          body[paramName] = ['test1', 'test2'];
+
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
+
+      const optionalListParameters = [
         'consumedAPIs',
         'providedAPIs',
         'producedEvents',
         'consumedEvents',
         'responsibles',
-      ])('no empty string in list-parameter %s', async (paramName: string) => {
-        const body: Record<string, string | string[]> = {
-          name: 'test',
-        };
-        body[paramName] = [''];
+      ];
+      it.each(optionalListParameters)(
+        'no empty string in list-parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string | string[]> = {
+            name: 'test',
+          };
+          body[paramName] = [''];
 
-        const accessToken = await getAccessToken();
-        await request(app.getHttpServer())
-          .post('/service-docs')
-          .auth(accessToken, { type: 'bearer' })
-          .send(body)
-          .expect(400);
-      });
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
+
+      it.each(optionalListParameters)(
+        'no number in list-parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string | number> = {
+            name: 'test',
+          };
+          body[paramName] = 1234;
+
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
+
+      it.each(optionalListParameters)(
+        'no object in list-parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string | object> = {
+            name: 'test',
+          };
+          body[paramName] = { test: 'tests' };
+
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
+
+      it.each(optionalListParameters)(
+        'no number list in list-parameter %s',
+        async (paramName: string) => {
+          const body: Record<string, string | number[]> = {
+            name: 'test',
+          };
+          body[paramName] = [1234];
+
+          const accessToken = await getAccessToken();
+          await request(app.getHttpServer())
+            .post('/service-docs')
+            .auth(accessToken, { type: 'bearer' })
+            .send(body)
+            .expect(400);
+        },
+      );
     });
 
     it('should create complex service-doc', async () => {


### PR DESCRIPTION
Closes #58

## Learnings
* The `class-validators` library seems to really need all those redundant `@IsString` annotations otherwise it also allows numbers, objects, arrays, etc. - at least in the configuration we use it.
* DTO models can be really crowded and confusing with all these annotations, esp. if done redundantly for API docs as well (swagger decorations)
* You can aggregate decorators by creating your custom decorators that might fix this issue.