### PR TITLE
Make URLs clickable

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
@@ -32,10 +32,10 @@ export const GroupDetails: React.FC = () => {
         >
           <Typography variant="h3">Group Information</Typography>
 
-          {controller.group.treeItemType ===
-            ServiceDocsTreeItemType.RegularGroup && (
-            <List>
-              <ListItem divider>
+          <List component="div">
+            {controller.group.treeItemType ===
+              ServiceDocsTreeItemType.RegularGroup && (
+              <ListItem component="div" divider>
                 <ListItemIcon>
                   <Icons.Badge />
                 </ListItemIcon>
@@ -44,13 +44,11 @@ export const GroupDetails: React.FC = () => {
                   secondary="Name"
                 />
               </ListItem>
-            </List>
-          )}
+            )}
 
-          {controller.group.treeItemType ===
-            ServiceDocsTreeItemType.RegularGroup && (
-            <List>
-              <ListItem divider>
+            {controller.group.treeItemType ===
+              ServiceDocsTreeItemType.RegularGroup && (
+              <ListItem component="div" divider>
                 <ListItemIcon>
                   <Icons.Group />
                 </ListItemIcon>
@@ -59,11 +57,9 @@ export const GroupDetails: React.FC = () => {
                   secondary="Full identifier"
                 />
               </ListItem>
-            </List>
-          )}
+            )}
 
-          <List>
-            <ListItem divider>
+            <ListItem component="div" divider>
               <ListItemIcon sx={{ color: 'inherit' }}>
                 <Icons.CenterFocusStrongOutlined />
               </ListItemIcon>
@@ -76,10 +72,8 @@ export const GroupDetails: React.FC = () => {
                 secondary="Number of owned services"
               />
             </ListItem>
-          </List>
 
-          <List>
-            <ListItem divider>
+            <ListItem component="div" divider>
               <ListItemIcon sx={{ color: 'inherit' }}>
                 <Icons.DatasetOutlined />
               </ListItemIcon>

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   List,
   ListItem,
+  ListItemButton,
   ListItemIcon,
   ListItemText,
   Typography,
@@ -33,8 +34,8 @@ export const ServiceDetails: React.FC = () => {
         >
           <Typography variant="h3">Base Information</Typography>
 
-          <List>
-            <ListItem divider>
+          <List component="div">
+            <ListItem component="div" divider>
               <ListItemIcon>
                 <Icons.Badge />
               </ListItemIcon>
@@ -45,7 +46,7 @@ export const ServiceDetails: React.FC = () => {
             </ListItem>
 
             {controller.service.group !== undefined && (
-              <ListItem divider>
+              <ListItem component="div" divider>
                 <ListItemIcon>
                   <Icons.Group />
                 </ListItemIcon>

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -57,7 +57,12 @@ export const ServiceDetails: React.FC = () => {
             )}
 
             {controller.service.repository !== undefined && (
-              <ListItem divider>
+              <ListItemButton
+                divider
+                onClick={(): void =>
+                  openURLIfPossible(controller.service?.repository)
+                }
+              >
                 <ListItemIcon>
                   <Icons.Code />
                 </ListItemIcon>
@@ -65,11 +70,16 @@ export const ServiceDetails: React.FC = () => {
                   primary={controller.service.repository}
                   secondary="Repository"
                 />
-              </ListItem>
+              </ListItemButton>
             )}
 
             {controller.service.taskBoard !== undefined && (
-              <ListItem divider>
+              <ListItemButton
+                divider
+                onClick={(): void =>
+                  openURLIfPossible(controller.service?.taskBoard)
+                }
+              >
                 <ListItemIcon>
                   <Icons.TaskAlt />
                 </ListItemIcon>
@@ -77,7 +87,7 @@ export const ServiceDetails: React.FC = () => {
                   primary={controller.service.taskBoard}
                   secondary="Task Board"
                 />
-              </ListItem>
+              </ListItemButton>
             )}
           </List>
 
@@ -107,4 +117,21 @@ function useController(): Controller {
   return {
     service: service,
   };
+}
+
+/**
+ * If the given URL is (probably) a valid web URL, open it in a new tab.
+ * Otherwise, do nothing.
+ *
+ * (We allow `undefined` to be passed as well, because this is needed in our template pretty often.)
+ */
+function openURLIfPossible(linkUrl: string | undefined): void {
+  if (
+    linkUrl === undefined ||
+    (!linkUrl.startsWith('http://') && !linkUrl.startsWith('https://'))
+  ) {
+    return;
+  }
+
+  window.open(linkUrl, '_blank');
 }


### PR DESCRIPTION
When clicking on the "Repository" or "Task Board" list item in the service details view, the respective URL is now opened. Originally, users would have to manually copy&paste these URLs in order to open them.

Also, this PR fixes some minor semantic inconsistencies.

One thing to note: I always render a `<ListItemButton` element, even if the link is not openable. This has the downside that, when hovering this element, the user might always get the impression that it is clickable (even if the link is invalid). This is probably not ideal for UX, but to avoid an overly complex implementation, I decided to do it like this for now.