### PR TITLE
Refactor the dependencies headings

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependencies.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependencies.tsx
@@ -15,7 +15,12 @@ import { generatePath, useNavigate } from 'react-router-dom';
 
 import { Icons } from '../../../../../icons';
 import { GROUPS_TREE_ROUTES_ABS } from '../../../../../routes';
-import { APINode, EventNode, MainNode } from '../../../service-docs-tree';
+import {
+  APINode,
+  EventNode,
+  MainNode,
+  ServiceDocsTreeNodeType,
+} from '../../../service-docs-tree';
 import { getAllAPIsAndEvents } from '../../../utils/service-docs-tree-utils';
 
 import { DependencyDetails } from './dependency-details';
@@ -29,7 +34,11 @@ export const Dependencies: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      <Typography variant="h3">Dependencies</Typography>
+      <Typography variant="h3">
+        {props.showDependenciesFor.type === ServiceDocsTreeNodeType.Service
+          ? 'Service Dependencies'
+          : 'Aggregated Dependencies'}
+      </Typography>
 
       <Box sx={{ marginTop: 2 }}>
         <Button


### PR DESCRIPTION
This PR implements the change requested in #67: When viewing a service, the heading of the Dependencies component now says "Service Dependencies". And when viewing a group, the heading now says "Aggregated Dependencies".

# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/199938370-1b9de7cc-71cd-4e8a-ab1a-c717418c4c0d.png)
![grafik](https://user-images.githubusercontent.com/8061217/199938392-70c54971-8d3d-40a1-81e0-ae5bc05cadc7.png)
