### PR TITLE
Sort various elements

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependencies.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependencies.tsx
@@ -173,6 +173,10 @@ function useController(props: Props): Controller {
       },
     ];
 
+    for (const item of result) {
+      sortAPIsOrEventsInPlace(item.data);
+    }
+
     return result;
   }, [props.showDependenciesFor]);
 
@@ -200,4 +204,14 @@ function useController(props: Props): Controller {
       );
     },
   };
+}
+
+/**
+ * Sort the given APIs or Events by their name.
+ * This function sorts in-place, i.e. it directly modifies the given array.
+ */
+function sortAPIsOrEventsInPlace(APIsOrEvents: APINode[] | EventNode[]): void {
+  APIsOrEvents.sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  });
 }

--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependency-details-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependency-details-item.tsx
@@ -103,7 +103,25 @@ function useController(props: Props): Controller {
     return props.dependency.consumedBy;
   }, [props.dependency, props.mode]);
 
+  const sortedServicesOfInterest = React.useMemo((): ServiceNode[] => {
+    const result = [...servicesOfInterest];
+
+    sortServicesInPlace(result);
+
+    return result;
+  }, [servicesOfInterest]);
+
   return {
-    servicesOfInterest: servicesOfInterest,
+    servicesOfInterest: sortedServicesOfInterest,
   };
+}
+
+/**
+ * Sort the given Services by their name.
+ * This function sorts in-place, i.e. it directly modifies the given array.
+ */
+function sortServicesInPlace(services: ServiceNode[]): void {
+  services.sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  });
 }


### PR DESCRIPTION
I noticed that, in multiple places, elements were not sorted by their name:
- In the tree view on the left, both services and groups were just displayed in a random order.
- In the "Dependencies" component, the APIs and Events were also just displayed in a random order.
- When clicking on one of the APIs/Events, the shown related Services were also displayed in a random order.

This PR fixes this by sorting these elements by their name.

# Screenshots

## Before

![grafik](https://user-images.githubusercontent.com/8061217/199939110-1dcf4d83-bffc-49a8-861e-7221b61805b2.png)
![grafik](https://user-images.githubusercontent.com/8061217/199939156-7050d200-a194-4556-899e-e51a410e3b8e.png)
![grafik](https://user-images.githubusercontent.com/8061217/199939238-2e948fb7-2c04-49da-bb02-5edd900f6a09.png)

## After
![grafik](https://user-images.githubusercontent.com/8061217/199939425-b80a7baf-027a-4e49-9a16-2c57ec92cbb8.png)
![grafik](https://user-images.githubusercontent.com/8061217/199939385-a5404977-0c9b-4454-8f0d-0fc6bbc1c1a3.png)
![grafik](https://user-images.githubusercontent.com/8061217/199939366-b0a70239-5bfb-437c-a2bd-4c4b6191824d.png)
