### PR TITLE
Fix a typo in the example request for the WebService

### DIFF
--- a/example/web.client.msadoc.json
+++ b/example/web.client.msadoc.json
@@ -11,7 +11,7 @@
     "/extractions/execution-stats",
 
     "/transformation/configs",
-    "transformation/execution-stats",
+    "/transformation/execution-stats",
 
     "/load/configs",
     "/load/execution-stats",


### PR DESCRIPTION
I have noticed that there is a typo in the example for the WebService. This PR fixes this typo.