### PR TITLE
Filter unrelated entries

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/sankey-data.ts
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/sankey-data.ts
@@ -59,6 +59,8 @@ export interface SankeyConfig {
 
   includeAPIs: boolean;
   includeEvents: boolean;
+
+  includeUnrelatedEntries: boolean;
 }
 
 /**
@@ -92,7 +94,7 @@ export function buildSankeyData(
   };
 
   for (const singleRawLink of rawLinks) {
-    if (!shouldIncludeLink(singleRawLink, sankeyConfig)) {
+    if (!shouldIncludeLink(singleRawLink, sankeyConfig, hopsGetterFn)) {
       continue;
     }
 
@@ -137,7 +139,11 @@ export function buildSankeyData(
   return result;
 }
 
-function shouldIncludeLink(link: RawLink, sankeyConfig: SankeyConfig): boolean {
+function shouldIncludeLink(
+  link: RawLink,
+  sankeyConfig: SankeyConfig,
+  hopsGetterFn: HopsGetterFn,
+): boolean {
   let connectingNode: ConnectingNode;
   if (link.type === 'from-service-or-group') {
     connectingNode = link.to;
@@ -154,6 +160,14 @@ function shouldIncludeLink(link: RawLink, sankeyConfig: SankeyConfig): boolean {
   if (
     connectingNode.type === ServiceDocsTreeNodeType.Event &&
     !sankeyConfig.includeEvents
+  ) {
+    return false;
+  }
+
+  if (
+    !sankeyConfig.includeUnrelatedEntries &&
+    (!isNodeDirectlyRelatedToPivotNode(link.from, hopsGetterFn) ||
+      !isNodeDirectlyRelatedToPivotNode(link.to, hopsGetterFn))
   ) {
     return false;
   }

--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-config.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-config.tsx
@@ -1,5 +1,15 @@
-import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormHelperText,
+  FormLabel,
+} from '@mui/material';
 import React from 'react';
+
+import { ServiceDocsTreeNodeType } from '../../../../service-docs-tree';
 
 import { SankeyConfig } from './sankey-data';
 
@@ -10,36 +20,74 @@ interface Props {
 }
 export const VisualizationConfig: React.FC<Props> = (props) => {
   return (
-    <FormGroup>
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={props.sankeyConfig.includeAPIs}
-            onChange={(e): void =>
-              props.setSankeyConfig({
-                ...props.sankeyConfig,
-                includeAPIs: e.target.checked,
-              })
-            }
-          />
-        }
-        label="Include APIs"
-      />
+    <Box>
+      <FormControl>
+        <FormLabel>APIs and Events</FormLabel>
 
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={props.sankeyConfig.includeEvents}
-            onChange={(e): void =>
-              props.setSankeyConfig({
-                ...props.sankeyConfig,
-                includeEvents: e.target.checked,
-              })
+        <FormGroup>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={props.sankeyConfig.includeAPIs}
+                onChange={(e): void =>
+                  props.setSankeyConfig({
+                    ...props.sankeyConfig,
+                    includeAPIs: e.target.checked,
+                  })
+                }
+              />
             }
+            label="Include APIs"
           />
-        }
-        label="Include Events"
-      />
-    </FormGroup>
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={props.sankeyConfig.includeEvents}
+                onChange={(e): void =>
+                  props.setSankeyConfig({
+                    ...props.sankeyConfig,
+                    includeEvents: e.target.checked,
+                  })
+                }
+              />
+            }
+            label="Include Events"
+          />
+        </FormGroup>
+      </FormControl>
+
+      {props.sankeyConfig.pivotNode.type !==
+        ServiceDocsTreeNodeType.RootGroup && (
+        <FormControl sx={{ marginTop: 3 }}>
+          <FormLabel>Unrelated entries</FormLabel>
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={props.sankeyConfig.includeUnrelatedEntries}
+                onChange={(e): void =>
+                  props.setSankeyConfig({
+                    ...props.sankeyConfig,
+                    includeUnrelatedEntries: e.target.checked,
+                  })
+                }
+              />
+            }
+            label="Include unrelated entries"
+          />
+
+          <FormHelperText>
+            {props.sankeyConfig.pivotNode.type ===
+              ServiceDocsTreeNodeType.Service &&
+              `Should entries be included that are not directly related to service "${props.sankeyConfig.pivotNode.name}"?`}
+
+            {props.sankeyConfig.pivotNode.type ===
+              ServiceDocsTreeNodeType.RegularGroup &&
+              `Should entries be included that are not directly related to group "${props.sankeyConfig.pivotNode.identifier}"?`}
+          </FormHelperText>
+        </FormControl>
+      )}
+    </Box>
   );
 };

--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-modal.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-modal.tsx
@@ -141,6 +141,8 @@ function useController(props: Props): Controller {
 
       includeAPIs: true,
       includeEvents: true,
+
+      includeUnrelatedEntries: true,
     },
   });
 

--- a/frontend/src/components/main-page/service-docs-tree.ts
+++ b/frontend/src/components/main-page/service-docs-tree.ts
@@ -266,7 +266,7 @@ function buildAndInsertServiceItems(
         );
 
         newServiceDocNode.consumedEvents.push(theEventNode);
-        theEventNode.producedBy.push(newServiceDocNode);
+        theEventNode.consumedBy.push(newServiceDocNode);
       }
     }
   }

--- a/frontend/src/components/main-page/utils/service-docs-tree-utils.ts
+++ b/frontend/src/components/main-page/utils/service-docs-tree-utils.ts
@@ -1,3 +1,4 @@
+import { addMultipleItemsToSet } from '../../../utils/set';
 import {
   APINode,
   EventNode,
@@ -74,10 +75,4 @@ export function getAllAPIsAndEvents(item: MainNode): APIsAndEvents {
   }
 
   return result;
-}
-
-function addMultipleItemsToSet<T>(items: T[], theSet: Set<T>): void {
-  for (const singleItem of items) {
-    theSet.add(singleItem);
-  }
 }

--- a/frontend/src/utils/set.ts
+++ b/frontend/src/utils/set.ts
@@ -1,0 +1,5 @@
+export function addMultipleItemsToSet<T>(items: T[], theSet: Set<T>): void {
+  for (const singleItem of items) {
+    theSet.add(singleItem);
+  }
+}


### PR DESCRIPTION
This PR makes it possible to remove all entries from the Sankey Diagram that are "unrelated" to the Pivot Node. Or, in other words: The user can now remove all nodes and links that are grey.

After I had implemented this, I noticed a bug in our Sankey Diagram: Some nodes would show up as being related to our Pivot Node, even if they weren't. This happened in a situation like this:

```
ServiceA --> Event --> PivotService
               |
               + ----> ServiceB
```

I expected only ServiceA and the PivotService to show up when filtering out the unrelated nodes. However, ServiceB would also show up (and ServiceB would also get a color, which means that the system has indeed assumed that ServiceB can be reached in 2 hops from the PivotService).

The reason for this was because when calculating the Hops, I did not pay attention to the "direction" in which we handle the APIs/Events. So we would simply say "OK, this Event is connected to the Pivot Service. Then all services consuming and producing this Event as reachable in 2 hops". From my point of view, this is not intuitive.

Thus, PR also fixes this issue by changing the way the Hops are calculated. In the example above, ServiceA still gets 2 hops, but ServiceB is assumed to be completely unrelated to the Pivot Service, leading to an infinite number of hops to be reported.


# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/199977857-6e2a1a30-6553-494e-b76a-ea857074c514.png)
![grafik](https://user-images.githubusercontent.com/8061217/199977893-0e016f1e-5389-42e2-85cc-6590f534358d.png)


## The fixed hops

### Before

![grafik](https://user-images.githubusercontent.com/8061217/199977646-53ab2aac-c96a-4e51-acb4-3154977db35b.png)

### After

![grafik](https://user-images.githubusercontent.com/8061217/199977754-695706d3-4f67-4e11-90ba-1ecfe6711c02.png)
