### PR TITLE
Refine the Sankey link tooltips to show a more detailed explanation of the respective connection

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/sankey-link-tooltip.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/sankey-link-tooltip.tsx
@@ -1,0 +1,212 @@
+import { Paper } from '@mui/material';
+import { SankeyLinkDatum } from '@nivo/sankey';
+import React from 'react';
+
+import {
+  RegularGroupNode,
+  ServiceDocsTreeNodeType,
+  ServiceNode,
+} from '../../../../service-docs-tree';
+import { isGroupXDescendantOfGroupY } from '../../../../utils/service-docs-tree-utils';
+
+import { CustomSankeyLink, CustomSankeyNode } from './sankey-data';
+
+interface Props {
+  link: SankeyLinkDatum<CustomSankeyNode, CustomSankeyLink>;
+}
+/**
+ * The tooltip that is being shown when hovering a link in the Sankey Diagram.
+ */
+export const SankeyLinkTooltip: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <Paper
+      elevation={1}
+      sx={{
+        background: '#ffffff',
+        paddingX: 2,
+        paddingY: 1,
+        maxWidth: '500px',
+      }}
+    >
+      {controller.tooltipText}
+    </Paper>
+  );
+};
+
+interface Controller {
+  tooltipText: string;
+}
+function useController(props: Props): Controller {
+  const tooltipText = ((): string => {
+    const sourceNode = props.link.source.customData.correspondingTreeNode;
+    const targetNode = props.link.target.customData.correspondingTreeNode;
+
+    // API --> Service
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.API &&
+      targetNode.type === ServiceDocsTreeNodeType.Service
+    ) {
+      return `Service "${sourceNode.name}" provides API "${targetNode.name}"`;
+    }
+    // Service --> API
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.Service &&
+      targetNode.type === ServiceDocsTreeNodeType.API
+    ) {
+      return `Service "${sourceNode.name}" consumes API "${targetNode.name}"`;
+    }
+    // Service --> Event
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.Service &&
+      targetNode.type === ServiceDocsTreeNodeType.Event
+    ) {
+      return `Service "${sourceNode.name}" produces event "${targetNode.name}"`;
+    }
+    // Event --> Service
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.Event &&
+      targetNode.type === ServiceDocsTreeNodeType.Service
+    ) {
+      return `Service "${targetNode.name}" consumes event "${sourceNode.name}"`;
+    }
+
+    // API --> Group
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.API &&
+      targetNode.type === ServiceDocsTreeNodeType.RegularGroup
+    ) {
+      const relatedServices = findServicesRelatedToGroup(
+        sourceNode.providedBy,
+        targetNode,
+      );
+      const formattedGroupName = formatGroupNameForTooltip(
+        targetNode,
+        relatedServices,
+      );
+      return `Group ${formattedGroupName} provides API "${sourceNode.name}"`;
+    }
+    // Group --> API
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.RegularGroup &&
+      targetNode.type === ServiceDocsTreeNodeType.API
+    ) {
+      const relatedServices = findServicesRelatedToGroup(
+        targetNode.consumedBy,
+        sourceNode,
+      );
+      const formattedGroupName = formatGroupNameForTooltip(
+        sourceNode,
+        relatedServices,
+      );
+      return `Group ${formattedGroupName} consumes API "${targetNode.name}"`;
+    }
+    // Group --> Event
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.RegularGroup &&
+      targetNode.type === ServiceDocsTreeNodeType.Event
+    ) {
+      const relatedServices = findServicesRelatedToGroup(
+        targetNode.producedBy,
+        sourceNode,
+      );
+      const formattedGroupName = formatGroupNameForTooltip(
+        sourceNode,
+        relatedServices,
+      );
+      return `Group ${formattedGroupName} produces event "${targetNode.name}"`;
+    }
+    // Event --> Group
+    if (
+      sourceNode.type === ServiceDocsTreeNodeType.Event &&
+      targetNode.type === ServiceDocsTreeNodeType.RegularGroup
+    ) {
+      const relatedServices = findServicesRelatedToGroup(
+        sourceNode.consumedBy,
+        targetNode,
+      );
+      const formattedGroupName = formatGroupNameForTooltip(
+        targetNode,
+        relatedServices,
+      );
+      return `Group ${formattedGroupName} consumes event "${sourceNode.name}"`;
+    }
+
+    console.warn(
+      'Found an unhandled combination of source and target node type',
+      props.link,
+    );
+    // A fallback, which should actually never be returned. We use this to be extra safe in case a new combination of source and target node type gets introduced in the future.
+    return `${props.link.source.label} > ${props.link.target.label}`;
+  })();
+
+  return {
+    tooltipText: tooltipText,
+  };
+}
+
+/**
+ * Build a string like one of the following:
+ *
+ * ``` txt
+ * "some.group.identifier" (service "some-service")
+ * "some.group.identifier" (services "some-service" and "another-service")
+ * "some.group.identifier" (services "some-service, "another-service" and "yet-another-service")
+ * ```
+ */
+function formatGroupNameForTooltip(
+  group: RegularGroupNode,
+  relatedServices: ServiceNode[],
+): string {
+  const serviceNamesWithQuotes: string[] = [];
+  for (const singleService of relatedServices) {
+    serviceNamesWithQuotes.push(`"${singleService.name}"`);
+  }
+
+  if (serviceNamesWithQuotes.length < 1) {
+    console.error(
+      'Found no services for the given group. This should not happen.',
+      group,
+    );
+    return '';
+  }
+
+  let servicesString: string;
+  if (serviceNamesWithQuotes.length === 1) {
+    servicesString = `service ${serviceNamesWithQuotes[0] ?? ''}`;
+  } else {
+    const allServicesExceptForLast = serviceNamesWithQuotes.slice(0, -1);
+    const lastService = serviceNamesWithQuotes.at(-1) ?? '';
+
+    servicesString = `services ${allServicesExceptForLast.join(
+      ',',
+    )} and ${lastService}`;
+  }
+
+  return `"${group.identifier}" (${servicesString})`;
+}
+
+/**
+ * From the given array of services, return these services that are related to the provided group (i.e. return the services that either directly belong to the group, or belong to one of the descendants of the provided group).
+ */
+function findServicesRelatedToGroup(
+  services: ServiceNode[],
+  group: RegularGroupNode,
+): ServiceNode[] {
+  return services.filter((singleService) => {
+    if (singleService.group.type === ServiceDocsTreeNodeType.RootGroup) {
+      return false;
+    }
+    if (singleService.group === group) {
+      return true;
+    }
+    if (
+      isGroupXDescendantOfGroupY({ xGroup: singleService.group, yGroup: group })
+    ) {
+      return true;
+    }
+
+    return false;
+  });
+}

--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-modal.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-modal.tsx
@@ -1,12 +1,5 @@
-import {
-  Box,
-  Dialog,
-  Divider,
-  IconButton,
-  Paper,
-  Tooltip,
-} from '@mui/material';
-import { ResponsiveSankey, SankeyLinkDatum } from '@nivo/sankey';
+import { Box, Dialog, Divider, IconButton, Tooltip } from '@mui/material';
+import { ResponsiveSankey } from '@nivo/sankey';
 import React from 'react';
 
 import { Icons } from '../../../../../../icons';
@@ -21,6 +14,7 @@ import {
   SankeyData,
   buildSankeyData,
 } from './sankey-data';
+import { SankeyLinkTooltip } from './sankey-link-tooltip';
 import { VisualizationConfig } from './visualization-config';
 
 interface Props {
@@ -108,7 +102,7 @@ export const VisualizationModal: React.FC<Props> = (props) => {
                 data={controller.sankeyData}
                 colors={(node): string => node.customData.color}
                 label={(node): string => node.customData.label}
-                linkTooltip={CustomLinkTooltip}
+                linkTooltip={SankeyLinkTooltip}
                 align={(node, maxDepth): number =>
                   getNodeAlignment(node as SankeyNodeWithDepth, maxDepth)
                 }
@@ -181,46 +175,3 @@ function getNodeAlignment(node: SankeyNodeWithDepth, maxDepth: number): number {
       return 2;
   }
 }
-
-/**
- * The tooltip that is being shown when hovering a link.
- */
-const CustomLinkTooltip: React.FC<{
-  link: SankeyLinkDatum<CustomSankeyNode, CustomSankeyLink>;
-}> = (props) => {
-  return (
-    <Paper
-      elevation={1}
-      sx={{
-        background: '#ffffff',
-        paddingX: 2,
-        paddingY: 1,
-        display: 'flex',
-        gap: 2,
-        alignItems: 'center',
-      }}
-    >
-      <Box
-        sx={{
-          background: props.link.source.color,
-          height: '15px',
-          width: '15px',
-        }}
-      />
-
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-        <span>{props.link.source.label}</span>
-        <Icons.ArrowForward />
-        <span>{props.link.target.label}</span>
-      </Box>
-
-      <Box
-        sx={{
-          background: props.link.target.color,
-          height: '15px',
-          width: '15px',
-        }}
-      />
-    </Paper>
-  );
-};


### PR DESCRIPTION
This PR implements the features described in #65: When hovering a link, a human-readable string is shown like "Service X consumes API Y".

There are quite a lot of cases we have to distinguish, which led to the rather long if-cascade. I did not find a better maintainable solution for this (at least none that is still readable), so I decided to go for this solution. If you have an idea for a better solution, then I would be really happy to implement that 😃 

One thing that we might consider in the future: Currently, there is no limit regarding how many services are listed in the tooltip. If we have a use case where there are really many services that provide a particular API/Event, then the tooltip might become huge. We could say something like `Group "my-group" (services "ServiceA", "ServiceB", "ServiceC" and 30 others) consume API "foo"`. But I had the feeling that this would be an overkill for now.

# Screenshots
![grafik](https://user-images.githubusercontent.com/8061217/200035206-ff346586-aed9-4b58-91da-2632496518c9.png)
![grafik](https://user-images.githubusercontent.com/8061217/200035248-c260413a-d6e7-4500-892f-95dacf7e4647.png)
![grafik](https://user-images.githubusercontent.com/8061217/200035285-7b315f3c-7e54-4471-b7ed-c5a778da364e.png)
![grafik](https://user-images.githubusercontent.com/8061217/200035319-fce5d042-7e88-4876-bb16-d8f10c86d90e.png)

