### PR TITLE
Show responsibles + documentations, improve the general UI design

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/common/data-container.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/data-container.tsx
@@ -1,0 +1,13 @@
+import { Paper } from '@mui/material';
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+export const DataContainer: React.FC<Props> = (props) => {
+  return (
+    <Paper elevation={24} sx={{ padding: 4 }}>
+      {props.children}
+    </Paper>
+  );
+};

--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependencies.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/dependencies.tsx
@@ -2,8 +2,6 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
   List,
   ListItemButton,
   ListItemIcon,
@@ -34,7 +32,7 @@ export const Dependencies: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      <Typography variant="h3">
+      <Typography variant="h4">
         {props.showDependenciesFor.type === ServiceDocsTreeNodeType.Service
           ? 'Service Dependencies'
           : 'Aggregated Dependencies'}
@@ -50,57 +48,54 @@ export const Dependencies: React.FC<Props> = (props) => {
       </Box>
 
       {controller.dependencyItems.map((dependencyItem) => (
-        <Card key={dependencyItem.type} sx={{ marginTop: 3 }}>
-          <CardContent>
-            <Typography variant="h5" component="div" sx={{ marginBottom: 2 }}>
-              {dependencyItem.type === 'provided-apis' && 'Provided APIs'}
-              {dependencyItem.type === 'consumed-apis' && 'Consumed APIs'}
-              {dependencyItem.type === 'published-events' && 'Published Events'}
+        <Box key={dependencyItem.type} sx={{ marginTop: 3 }}>
+          <Typography variant="h5" component="div" sx={{ marginBottom: 2 }}>
+            {dependencyItem.type === 'provided-apis' && 'Provided APIs'}
+            {dependencyItem.type === 'consumed-apis' && 'Consumed APIs'}
+            {dependencyItem.type === 'published-events' && 'Published Events'}
+            {dependencyItem.type === 'subscribed-events' && 'Subscribed Events'}
+          </Typography>
+
+          {dependencyItem.data.length < 1 && (
+            <Alert severity="info">
+              {dependencyItem.type === 'provided-apis' && 'No provided APIs'}
+              {dependencyItem.type === 'consumed-apis' && 'No consumed APIs'}
+              {dependencyItem.type === 'published-events' &&
+                'No published events'}
               {dependencyItem.type === 'subscribed-events' &&
-                'Subscribed Events'}
-            </Typography>
+                'No subscribed events'}
+            </Alert>
+          )}
 
-            {dependencyItem.data.length < 1 && (
-              <Alert severity="info">
-                {dependencyItem.type === 'provided-apis' && 'No provided APIs'}
-                {dependencyItem.type === 'consumed-apis' && 'No consumed APIs'}
-                {dependencyItem.type === 'published-events' &&
-                  'No published events'}
-                {dependencyItem.type === 'subscribed-events' &&
-                  'No subscribed events'}
-              </Alert>
-            )}
-
-            {dependencyItem.data.length > 0 && (
-              <List component="div">
-                {dependencyItem.data.map((apiOrEvent) => (
-                  <ListItemButton
-                    key={apiOrEvent.name}
-                    onClick={(): void =>
-                      controller.showDependencyDialog(apiOrEvent)
-                    }
-                  >
-                    <ListItemIcon>
-                      {dependencyItem.type === 'provided-apis' && (
-                        <Icons.CloudUploadOutlined />
-                      )}
-                      {dependencyItem.type === 'consumed-apis' && (
-                        <Icons.CloudDownloadOutlined />
-                      )}
-                      {dependencyItem.type === 'published-events' && (
-                        <Icons.UnarchiveOutlined />
-                      )}
-                      {dependencyItem.type === 'subscribed-events' && (
-                        <Icons.ArchiveOutlined />
-                      )}
-                    </ListItemIcon>
-                    <ListItemText>{apiOrEvent.name}</ListItemText>
-                  </ListItemButton>
-                ))}
-              </List>
-            )}
-          </CardContent>
-        </Card>
+          {dependencyItem.data.length > 0 && (
+            <List component="div">
+              {dependencyItem.data.map((apiOrEvent) => (
+                <ListItemButton
+                  key={apiOrEvent.name}
+                  onClick={(): void =>
+                    controller.showDependencyDialog(apiOrEvent)
+                  }
+                >
+                  <ListItemIcon>
+                    {dependencyItem.type === 'provided-apis' && (
+                      <Icons.CloudUploadOutlined />
+                    )}
+                    {dependencyItem.type === 'consumed-apis' && (
+                      <Icons.CloudDownloadOutlined />
+                    )}
+                    {dependencyItem.type === 'published-events' && (
+                      <Icons.UnarchiveOutlined />
+                    )}
+                    {dependencyItem.type === 'subscribed-events' && (
+                      <Icons.ArchiveOutlined />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText>{apiOrEvent.name}</ListItemText>
+                </ListItemButton>
+              ))}
+            </List>
+          )}
+        </Box>
       ))}
 
       {controller.state.dependencyDialogData && (

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/group-responsibilities.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/group-responsibilities.tsx
@@ -1,0 +1,180 @@
+import { Alert, Box, Chip, Typography } from '@mui/material';
+import React from 'react';
+import { generatePath, useNavigate } from 'react-router-dom';
+
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../../routes';
+import { addMultipleItemsToSet } from '../../../../../utils/set';
+import { RegularGroupNode, RootGroupNode } from '../../../service-docs-tree';
+import { extractAllServices } from '../../../utils/service-docs-tree-utils';
+
+import { ResponsibleDetails } from './responsible-details';
+import { TeamDetails } from './team-details';
+
+interface Props {
+  showResponsiblesFor: RegularGroupNode | RootGroupNode;
+}
+export const GroupResponsibilities: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <React.Fragment>
+      <Typography variant="h5" component="div" sx={{ marginBottom: 2 }}>
+        Responsible Teams
+      </Typography>
+
+      {controller.teams.length < 1 && (
+        <Alert severity="info">No responsible teams defined</Alert>
+      )}
+
+      {controller.teams.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {controller.teams.map((singleTeam) => (
+            <Chip
+              key={singleTeam}
+              label={singleTeam}
+              onClick={(): void =>
+                controller.setViewState({
+                  mode: 'show-team-details',
+                  team: singleTeam,
+                })
+              }
+            />
+          ))}
+        </Box>
+      )}
+
+      <Typography variant="h5" component="div" sx={{ marginY: 2 }}>
+        Responsibles
+      </Typography>
+
+      {controller.responsibles.length < 1 && (
+        <Alert severity="info">No Responsibles defined</Alert>
+      )}
+
+      {controller.responsibles.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {controller.responsibles.map((singleResponsible) => (
+            <Chip
+              key={singleResponsible}
+              label={singleResponsible}
+              onClick={(): void =>
+                controller.setViewState({
+                  mode: 'show-responsible-details',
+                  responsible: singleResponsible,
+                })
+              }
+            />
+          ))}
+        </Box>
+      )}
+
+      {controller.state.viewState.mode === 'show-team-details' && (
+        <TeamDetails
+          team={controller.state.viewState.team}
+          currentServiceOrGroup={props.showResponsiblesFor}
+          close={(): void => controller.setViewState({ mode: 'default' })}
+          goToService={(serviceName: string): void => {
+            controller.setViewState({ mode: 'default' });
+            controller.goToService(serviceName);
+          }}
+        />
+      )}
+
+      {controller.state.viewState.mode === 'show-responsible-details' && (
+        <ResponsibleDetails
+          responsible={controller.state.viewState.responsible}
+          currentServiceOrGroup={props.showResponsiblesFor}
+          close={(): void => controller.setViewState({ mode: 'default' })}
+          goToService={(serviceName: string): void => {
+            controller.setViewState({ mode: 'default' });
+            controller.goToService(serviceName);
+          }}
+        />
+      )}
+    </React.Fragment>
+  );
+};
+
+type ViewState =
+  | DefaultViewState
+  | ShowTeamDetailsViewState
+  | ShowResponsibleDetailsViewState;
+interface DefaultViewState {
+  mode: 'default';
+}
+interface ShowTeamDetailsViewState {
+  mode: 'show-team-details';
+  team: string;
+}
+interface ShowResponsibleDetailsViewState {
+  mode: 'show-responsible-details';
+  responsible: string;
+}
+
+interface State {
+  viewState: ViewState;
+}
+interface Controller {
+  state: State;
+
+  teams: string[];
+  responsibles: string[];
+
+  setViewState: (viewState: ViewState) => void;
+
+  goToService: (serviceName: string) => void;
+}
+function useController(props: Props): Controller {
+  const navigate = useNavigate();
+
+  const [state, setState] = React.useState<State>({
+    viewState: {
+      mode: 'default',
+    },
+  });
+
+  const [teams, responsibles] = React.useMemo((): [string[], string[]] => {
+    const allTeams = new Set<string>();
+    const allResponsibles = new Set<string>();
+
+    const allServices = extractAllServices(props.showResponsiblesFor);
+    for (const singleService of allServices) {
+      if (singleService.responsibleTeam !== undefined) {
+        allTeams.add(singleService.responsibleTeam);
+      }
+
+      addMultipleItemsToSet(singleService.responsibles ?? [], allResponsibles);
+    }
+
+    const sortedTeams = Array.from(allTeams);
+    sortedTeams.sort((a, b) => {
+      return a.localeCompare(b);
+    });
+
+    const sortedResponsibles = Array.from(allResponsibles);
+    sortedResponsibles.sort((a, b) => {
+      return a.localeCompare(b);
+    });
+
+    return [sortedTeams, sortedResponsibles];
+  }, [props.showResponsiblesFor]);
+
+  return {
+    state: state,
+
+    teams: teams,
+    responsibles: responsibles,
+
+    setViewState: (viewState): void => {
+      setState((state) => ({ ...state, viewState: viewState }));
+    },
+
+    goToService: (serviceName: string): void => {
+      navigate(
+        generatePath(GROUPS_TREE_ROUTES_ABS.service, {
+          service: serviceName,
+        }),
+      );
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/index.ts
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/index.ts
@@ -1,0 +1,1 @@
+export { Responsibilities } from './responsibilities';

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/responsibilities.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/responsibilities.tsx
@@ -1,0 +1,35 @@
+import { Box, Typography } from '@mui/material';
+import React from 'react';
+
+import { MainNode, ServiceDocsTreeNodeType } from '../../../service-docs-tree';
+
+import { GroupResponsibilities } from './group-responsibilities';
+import { ServiceResponsibilities } from './service-responsibilities';
+
+interface Props {
+  showResponsibilitiesFor: MainNode;
+}
+export const Responsibilities: React.FC<Props> = (props) => {
+  return (
+    <React.Fragment>
+      <Typography variant="h3">
+        {props.showResponsibilitiesFor.type === ServiceDocsTreeNodeType.Service
+          ? 'Responsibilities'
+          : 'Aggregated Responsibilities'}
+      </Typography>
+
+      <Box sx={{ marginTop: 2 }}>
+        {props.showResponsibilitiesFor.type ===
+        ServiceDocsTreeNodeType.Service ? (
+          <ServiceResponsibilities
+            showResponsiblesFor={props.showResponsibilitiesFor}
+          />
+        ) : (
+          <GroupResponsibilities
+            showResponsiblesFor={props.showResponsibilitiesFor}
+          />
+        )}
+      </Box>
+    </React.Fragment>
+  );
+};

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/responsibilities.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/responsibilities.tsx
@@ -12,7 +12,7 @@ interface Props {
 export const Responsibilities: React.FC<Props> = (props) => {
   return (
     <React.Fragment>
-      <Typography variant="h3">
+      <Typography variant="h4">
         {props.showResponsibilitiesFor.type === ServiceDocsTreeNodeType.Service
           ? 'Responsibilities'
           : 'Aggregated Responsibilities'}

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/responsible-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/responsible-details.tsx
@@ -1,0 +1,94 @@
+import {
+  Dialog,
+  DialogContent,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+
+import { Icons } from '../../../../../icons';
+import {
+  MainNode,
+  ServiceDocsTreeNodeType,
+  ServiceNode,
+} from '../../../service-docs-tree';
+import { useServiceDocsServiceContext } from '../../../services/service-docs-service';
+import { sortServicesByName } from '../../../utils/service-docs-tree-utils';
+
+interface Props {
+  responsible: string;
+
+  currentServiceOrGroup: MainNode;
+
+  close: () => void;
+  goToService: (serviceName: string) => void;
+}
+export const ResponsibleDetails: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <Dialog open onClose={(): void => props.close()}>
+      <DialogContent sx={{ width: '500px' }}>
+        <Typography variant="h4" sx={{ overflowWrap: 'anywhere' }}>
+          Responsible Details
+        </Typography>
+
+        <Typography variant="subtitle1">
+          {`Responsible "${props.responsible}" is listed in the following services.`}
+        </Typography>
+
+        <List>
+          {controller.servicesOfInterest.map((service) => (
+            <ListItemButton
+              key={service.name}
+              disabled={
+                props.currentServiceOrGroup.type ===
+                  ServiceDocsTreeNodeType.Service &&
+                service === props.currentServiceOrGroup
+              }
+              onClick={(): void => props.goToService(service.name)}
+            >
+              <ListItemIcon>
+                <Icons.CenterFocusStrongOutlined />
+              </ListItemIcon>
+              <ListItemText>{service.name}</ListItemText>
+            </ListItemButton>
+          ))}
+        </List>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface Controller {
+  servicesOfInterest: ServiceNode[];
+}
+function useController(props: Props): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const servicesOfInterest = React.useMemo((): ServiceNode[] => {
+    let result: ServiceNode[] = serviceDocsService.serviceDocs.filter(
+      (service) => {
+        if (
+          !service.responsibles ||
+          !service.responsibles.includes(props.responsible)
+        ) {
+          return false;
+        }
+
+        return true;
+      },
+    );
+
+    result = sortServicesByName(result);
+
+    return result;
+  }, [props.responsible, serviceDocsService.serviceDocs]);
+
+  return {
+    servicesOfInterest: servicesOfInterest,
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/service-responsibilities.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/service-responsibilities.tsx
@@ -1,0 +1,177 @@
+import {
+  Alert,
+  Box,
+  Chip,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import { generatePath, useNavigate } from 'react-router-dom';
+
+import { Icons } from '../../../../../icons';
+import { GROUPS_TREE_ROUTES_ABS } from '../../../../../routes';
+import { ServiceNode } from '../../../service-docs-tree';
+
+import { ResponsibleDetails } from './responsible-details';
+import { TeamDetails } from './team-details';
+
+interface Props {
+  showResponsiblesFor: ServiceNode;
+}
+export const ServiceResponsibilities: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <React.Fragment>
+      {props.showResponsiblesFor.responsibleTeam === undefined && (
+        <Alert severity="info">No responsible team defined</Alert>
+      )}
+
+      {props.showResponsiblesFor.responsibleTeam !== undefined && (
+        <List component="div">
+          <ListItemButton
+            component="div"
+            onClick={(): void => {
+              if (props.showResponsiblesFor.responsibleTeam === undefined) {
+                return;
+              }
+              controller.setViewState({
+                mode: 'show-team-details',
+                team: props.showResponsiblesFor.responsibleTeam,
+              });
+            }}
+          >
+            <ListItemIcon>
+              <Icons.Badge />
+            </ListItemIcon>
+            <ListItemText
+              primary={props.showResponsiblesFor.responsibleTeam}
+              secondary="Responsible team"
+            />
+          </ListItemButton>
+        </List>
+      )}
+
+      <Typography variant="h5" component="div" sx={{ marginY: 2 }}>
+        Responsibles
+      </Typography>
+
+      {controller.responsibles.length < 1 && (
+        <Alert severity="info">No Responsibles defined</Alert>
+      )}
+
+      {controller.responsibles.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {controller.responsibles.map((singleResponsible) => (
+            <Chip
+              key={singleResponsible}
+              label={singleResponsible}
+              onClick={(): void =>
+                controller.setViewState({
+                  mode: 'show-responsible-details',
+                  responsible: singleResponsible,
+                })
+              }
+            />
+          ))}
+        </Box>
+      )}
+
+      {controller.state.viewState.mode === 'show-team-details' && (
+        <TeamDetails
+          team={controller.state.viewState.team}
+          currentServiceOrGroup={props.showResponsiblesFor}
+          close={(): void => controller.setViewState({ mode: 'default' })}
+          goToService={(serviceName: string): void => {
+            controller.setViewState({ mode: 'default' });
+            controller.goToService(serviceName);
+          }}
+        />
+      )}
+
+      {controller.state.viewState.mode === 'show-responsible-details' && (
+        <ResponsibleDetails
+          responsible={controller.state.viewState.responsible}
+          currentServiceOrGroup={props.showResponsiblesFor}
+          close={(): void => controller.setViewState({ mode: 'default' })}
+          goToService={(serviceName: string): void => {
+            controller.setViewState({ mode: 'default' });
+            controller.goToService(serviceName);
+          }}
+        />
+      )}
+    </React.Fragment>
+  );
+};
+
+type ViewState =
+  | DefaultViewState
+  | ShowTeamDetailsViewState
+  | ShowResponsibleDetailsViewState;
+interface DefaultViewState {
+  mode: 'default';
+}
+interface ShowTeamDetailsViewState {
+  mode: 'show-team-details';
+  team: string;
+}
+interface ShowResponsibleDetailsViewState {
+  mode: 'show-responsible-details';
+  responsible: string;
+}
+
+interface State {
+  viewState: ViewState;
+}
+interface Controller {
+  state: State;
+
+  responsibles: string[];
+
+  setViewState: (viewState: ViewState) => void;
+
+  goToService: (serviceName: string) => void;
+}
+function useController(props: Props): Controller {
+  const navigate = useNavigate();
+
+  const [state, setState] = React.useState<State>({
+    viewState: {
+      mode: 'default',
+    },
+  });
+
+  const responsibles = React.useMemo((): string[] => {
+    if (!props.showResponsiblesFor.responsibles) {
+      return [];
+    }
+
+    const result = [...props.showResponsiblesFor.responsibles];
+    result.sort((a, b) => {
+      return a.localeCompare(b);
+    });
+
+    return result;
+  }, [props.showResponsiblesFor]);
+
+  return {
+    state: state,
+
+    responsibles: responsibles,
+
+    setViewState: (viewState): void => {
+      setState((state) => ({ ...state, viewState: viewState }));
+    },
+
+    goToService: (serviceName: string): void => {
+      navigate(
+        generatePath(GROUPS_TREE_ROUTES_ABS.service, {
+          service: serviceName,
+        }),
+      );
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/service-responsibilities.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/service-responsibilities.tsx
@@ -34,6 +34,7 @@ export const ServiceResponsibilities: React.FC<Props> = (props) => {
         <List component="div">
           <ListItemButton
             component="div"
+            divider
             onClick={(): void => {
               if (props.showResponsiblesFor.responsibleTeam === undefined) {
                 return;

--- a/frontend/src/components/main-page/groups-tree-page/common/responsibilities/team-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/responsibilities/team-details.tsx
@@ -1,0 +1,91 @@
+import {
+  Dialog,
+  DialogContent,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+
+import { Icons } from '../../../../../icons';
+import {
+  MainNode,
+  ServiceDocsTreeNodeType,
+  ServiceNode,
+} from '../../../service-docs-tree';
+import { useServiceDocsServiceContext } from '../../../services/service-docs-service';
+import { sortServicesByName } from '../../../utils/service-docs-tree-utils';
+
+interface Props {
+  team: string;
+
+  currentServiceOrGroup: MainNode;
+
+  close: () => void;
+  goToService: (serviceName: string) => void;
+}
+export const TeamDetails: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <Dialog open onClose={(): void => props.close()}>
+      <DialogContent sx={{ width: '500px' }}>
+        <Typography variant="h4" sx={{ overflowWrap: 'anywhere' }}>
+          Team Details
+        </Typography>
+
+        <Typography variant="subtitle1">
+          {`Team "${props.team}" is listed in the following services.`}
+        </Typography>
+
+        <List>
+          {controller.servicesOfInterest.map((service) => (
+            <ListItemButton
+              key={service.name}
+              disabled={
+                props.currentServiceOrGroup.type ===
+                  ServiceDocsTreeNodeType.Service &&
+                service === props.currentServiceOrGroup
+              }
+              onClick={(): void => props.goToService(service.name)}
+            >
+              <ListItemIcon>
+                <Icons.CenterFocusStrongOutlined />
+              </ListItemIcon>
+              <ListItemText>{service.name}</ListItemText>
+            </ListItemButton>
+          ))}
+        </List>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+interface Controller {
+  servicesOfInterest: ServiceNode[];
+}
+function useController(props: Props): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const servicesOfInterest = React.useMemo((): ServiceNode[] => {
+    let result: ServiceNode[] = serviceDocsService.serviceDocs.filter(
+      (service) => {
+        if (service.responsibleTeam === props.team) {
+          return true;
+        }
+
+        return false;
+      },
+    );
+
+    result = sortServicesByName(result);
+
+    return result;
+  }, [props.team, serviceDocsService.serviceDocs]);
+
+  return {
+    servicesOfInterest: servicesOfInterest,
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/common/tags/tags.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/tags/tags.tsx
@@ -17,7 +17,7 @@ export const Tags: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      <Typography variant="h3">
+      <Typography variant="h4">
         {props.showTagsFor.type === ServiceDocsTreeNodeType.Service
           ? 'Tags'
           : 'Aggregated Tags'}

--- a/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../service-docs-tree';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import { Dependencies } from '../common/dependencies';
+import { Responsibilities } from '../common/responsibilities';
 import { Tags } from '../common/tags';
 
 export const GroupDetails: React.FC = () => {
@@ -87,6 +88,10 @@ export const GroupDetails: React.FC = () => {
               />
             </ListItem>
           </List>
+
+          <Box sx={{ marginTop: 3 }}>
+            <Responsibilities showResponsibilitiesFor={controller.group} />
+          </Box>
 
           <Box sx={{ marginTop: 3 }}>
             <Tags showTagsFor={controller.group} />

--- a/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/group-details/group-details.tsx
@@ -15,6 +15,7 @@ import {
   ServiceDocsTreeNodeType,
 } from '../../service-docs-tree';
 import { useSelectedTreeItem } from '../../utils/router-utils';
+import { DataContainer } from '../common/data-container';
 import { Dependencies } from '../common/dependencies';
 import { Responsibilities } from '../common/responsibilities';
 import { Tags } from '../common/tags';
@@ -29,77 +30,88 @@ export const GroupDetails: React.FC = () => {
           sx={{
             overflowX: 'hidden',
             overflowY: 'auto',
-            padding: 4,
-            maxWidth: '700px',
+            paddingX: 8,
+            paddingBottom: 10,
+            paddingTop: 3,
+            maxWidth: '800px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 5,
           }}
         >
-          <Typography variant="h3">Group Information</Typography>
+          <DataContainer>
+            <Typography variant="h4">Group Information</Typography>
 
-          <List component="div">
-            {controller.group.type === ServiceDocsTreeNodeType.RegularGroup && (
+            <List component="div">
+              {controller.group.type ===
+                ServiceDocsTreeNodeType.RegularGroup && (
+                <ListItem component="div" divider>
+                  <ListItemIcon>
+                    <Icons.Badge />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={controller.group.name}
+                    secondary="Name"
+                  />
+                </ListItem>
+              )}
+
+              {controller.group.type ===
+                ServiceDocsTreeNodeType.RegularGroup && (
+                <ListItem component="div" divider>
+                  <ListItemIcon>
+                    <Icons.Group />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={controller.group.identifier}
+                    secondary="Full identifier"
+                  />
+                </ListItem>
+              )}
+
               <ListItem component="div" divider>
-                <ListItemIcon>
-                  <Icons.Badge />
+                <ListItemIcon sx={{ color: 'inherit' }}>
+                  <Icons.CenterFocusStrongOutlined />
                 </ListItemIcon>
                 <ListItemText
-                  primary={controller.group.name}
-                  secondary="Name"
+                  primary={`${controller.group.services.length} ${
+                    controller.group.services.length === 1
+                      ? 'Service'
+                      : 'Services'
+                  }`}
+                  secondary="Number of owned services"
                 />
               </ListItem>
-            )}
 
-            {controller.group.type === ServiceDocsTreeNodeType.RegularGroup && (
               <ListItem component="div" divider>
-                <ListItemIcon>
-                  <Icons.Group />
+                <ListItemIcon sx={{ color: 'inherit' }}>
+                  <Icons.DatasetOutlined />
                 </ListItemIcon>
                 <ListItemText
-                  primary={controller.group.identifier}
-                  secondary="Full identifier"
+                  primary={`${
+                    Object.keys(controller.group.childGroups).length
+                  } ${
+                    Object.keys(controller.group.childGroups).length === 1
+                      ? 'Group'
+                      : 'Groups'
+                  }`}
+                  secondary="Number of owned groups"
                 />
               </ListItem>
-            )}
+            </List>
+          </DataContainer>
 
-            <ListItem component="div" divider>
-              <ListItemIcon sx={{ color: 'inherit' }}>
-                <Icons.CenterFocusStrongOutlined />
-              </ListItemIcon>
-              <ListItemText
-                primary={`${controller.group.services.length} ${
-                  controller.group.services.length === 1
-                    ? 'Service'
-                    : 'Services'
-                }`}
-                secondary="Number of owned services"
-              />
-            </ListItem>
-
-            <ListItem component="div" divider>
-              <ListItemIcon sx={{ color: 'inherit' }}>
-                <Icons.DatasetOutlined />
-              </ListItemIcon>
-              <ListItemText
-                primary={`${Object.keys(controller.group.childGroups).length} ${
-                  Object.keys(controller.group.childGroups).length === 1
-                    ? 'Group'
-                    : 'Groups'
-                }`}
-                secondary="Number of owned groups"
-              />
-            </ListItem>
-          </List>
-
-          <Box sx={{ marginTop: 3 }}>
+          <DataContainer>
             <Responsibilities showResponsibilitiesFor={controller.group} />
-          </Box>
+          </DataContainer>
 
-          <Box sx={{ marginTop: 3 }}>
+          <DataContainer>
             <Tags showTagsFor={controller.group} />
-          </Box>
+          </DataContainer>
 
-          <Box sx={{ marginTop: 3 }}>
+          <DataContainer>
             <Dependencies showDependenciesFor={controller.group} />
-          </Box>
+          </DataContainer>
         </Box>
       )}
     </React.Fragment>

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -13,6 +13,7 @@ import { Icons } from '../../../../icons';
 import { ServiceDocsTreeNodeType, ServiceNode } from '../../service-docs-tree';
 import { useSelectedTreeItem } from '../../utils/router-utils';
 import { Dependencies } from '../common/dependencies';
+import { Responsibilities } from '../common/responsibilities';
 import { Tags } from '../common/tags';
 
 export const ServiceDetails: React.FC = () => {
@@ -92,6 +93,10 @@ export const ServiceDetails: React.FC = () => {
 
           <Box sx={{ marginTop: 3 }}>
             <Tags showTagsFor={controller.service} />
+          </Box>
+
+          <Box sx={{ marginTop: 3 }}>
+            <Responsibilities showResponsibilitiesFor={controller.service} />
           </Box>
 
           <Box sx={{ marginTop: 3 }}>

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   List,
   ListItem,
@@ -97,6 +98,74 @@ export const ServiceDetails: React.FC = () => {
                 </ListItemButton>
               )}
             </List>
+          </DataContainer>
+
+          <DataContainer>
+            <Typography variant="h4">Documentation</Typography>
+
+            {controller.service.developmentDocumentation === undefined &&
+            controller.service.deploymentDocumentation === undefined &&
+            controller.service.apiDocumentation === undefined ? (
+              <Alert severity="info" sx={{ marginTop: 2 }}>
+                No documentation URLs defined
+              </Alert>
+            ) : (
+              <List component="div">
+                {controller.service.developmentDocumentation !== undefined && (
+                  <ListItemButton
+                    divider
+                    onClick={(): void =>
+                      openURLIfPossible(
+                        controller.service?.developmentDocumentation,
+                      )
+                    }
+                  >
+                    <ListItemIcon>
+                      <Icons.IntegrationInstructions />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={controller.service.developmentDocumentation}
+                      secondary="Development Documentation"
+                    />
+                  </ListItemButton>
+                )}
+                {controller.service.deploymentDocumentation !== undefined && (
+                  <ListItemButton
+                    divider
+                    onClick={(): void =>
+                      openURLIfPossible(
+                        controller.service?.deploymentDocumentation,
+                      )
+                    }
+                  >
+                    <ListItemIcon>
+                      <Icons.CloudUpload />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={controller.service.deploymentDocumentation}
+                      secondary="Deployment Documentation"
+                    />
+                  </ListItemButton>
+                )}
+
+                {controller.service.apiDocumentation !== undefined && (
+                  <ListItemButton
+                    divider
+                    onClick={(): void =>
+                      openURLIfPossible(controller.service?.apiDocumentation)
+                    }
+                  >
+                    <ListItemIcon>
+                      <Icons.Assignment />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={controller.service.apiDocumentation}
+                      secondary="API Documentation"
+                    />
+                  </ListItemButton>
+                )}
+              </List>
+            )}
           </DataContainer>
 
           <DataContainer>

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { Icons } from '../../../../icons';
 import { ServiceDocsTreeNodeType, ServiceNode } from '../../service-docs-tree';
 import { useSelectedTreeItem } from '../../utils/router-utils';
+import { DataContainer } from '../common/data-container';
 import { Dependencies } from '../common/dependencies';
 import { Responsibilities } from '../common/responsibilities';
 import { Tags } from '../common/tags';
@@ -26,82 +27,89 @@ export const ServiceDetails: React.FC = () => {
           sx={{
             overflowX: 'hidden',
             overflowY: 'auto',
-            padding: 4,
-            maxWidth: '700px',
+            paddingX: 8,
+            paddingBottom: 10,
+            paddingTop: 3,
+            maxWidth: '800px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 5,
           }}
         >
-          <Typography variant="h3">Base Information</Typography>
+          <DataContainer>
+            <Typography variant="h4">Base Information</Typography>
 
-          <List component="div">
-            <ListItem component="div" divider>
-              <ListItemIcon>
-                <Icons.Badge />
-              </ListItemIcon>
-              <ListItemText
-                primary={controller.service.name}
-                secondary="Name"
-              />
-            </ListItem>
-
-            {controller.service.group.type ===
-              ServiceDocsTreeNodeType.RegularGroup && (
+            <List component="div">
               <ListItem component="div" divider>
                 <ListItemIcon>
-                  <Icons.Group />
+                  <Icons.Badge />
                 </ListItemIcon>
                 <ListItemText
-                  primary={controller.service.group.name}
-                  secondary="Group"
+                  primary={controller.service.name}
+                  secondary="Name"
                 />
               </ListItem>
-            )}
 
-            {controller.service.repository !== undefined && (
-              <ListItemButton
-                divider
-                onClick={(): void =>
-                  openURLIfPossible(controller.service?.repository)
-                }
-              >
-                <ListItemIcon>
-                  <Icons.Code />
-                </ListItemIcon>
-                <ListItemText
-                  primary={controller.service.repository}
-                  secondary="Repository"
-                />
-              </ListItemButton>
-            )}
+              {controller.service.group.type ===
+                ServiceDocsTreeNodeType.RegularGroup && (
+                <ListItem component="div" divider>
+                  <ListItemIcon>
+                    <Icons.Group />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={controller.service.group.name}
+                    secondary="Group"
+                  />
+                </ListItem>
+              )}
 
-            {controller.service.taskBoard !== undefined && (
-              <ListItemButton
-                divider
-                onClick={(): void =>
-                  openURLIfPossible(controller.service?.taskBoard)
-                }
-              >
-                <ListItemIcon>
-                  <Icons.TaskAlt />
-                </ListItemIcon>
-                <ListItemText
-                  primary={controller.service.taskBoard}
-                  secondary="Task Board"
-                />
-              </ListItemButton>
-            )}
-          </List>
+              {controller.service.repository !== undefined && (
+                <ListItemButton
+                  divider
+                  onClick={(): void =>
+                    openURLIfPossible(controller.service?.repository)
+                  }
+                >
+                  <ListItemIcon>
+                    <Icons.Code />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={controller.service.repository}
+                    secondary="Repository"
+                  />
+                </ListItemButton>
+              )}
 
-          <Box sx={{ marginTop: 3 }}>
+              {controller.service.taskBoard !== undefined && (
+                <ListItemButton
+                  divider
+                  onClick={(): void =>
+                    openURLIfPossible(controller.service?.taskBoard)
+                  }
+                >
+                  <ListItemIcon>
+                    <Icons.TaskAlt />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={controller.service.taskBoard}
+                    secondary="Task Board"
+                  />
+                </ListItemButton>
+              )}
+            </List>
+          </DataContainer>
+
+          <DataContainer>
             <Tags showTagsFor={controller.service} />
-          </Box>
+          </DataContainer>
 
-          <Box sx={{ marginTop: 3 }}>
+          <DataContainer>
             <Responsibilities showResponsibilitiesFor={controller.service} />
-          </Box>
+          </DataContainer>
 
-          <Box sx={{ marginTop: 3 }}>
+          <DataContainer>
             <Dependencies showDependenciesFor={controller.service} />
-          </Box>
+          </DataContainer>
         </Box>
       )}
     </React.Fragment>


### PR DESCRIPTION
This PR:
- Add a section called "Responsibles" to our service view, and a section called "Aggregated Responsibles" to our group view. When clicking on a Responsible (i.e. a person) or on a team, other services are shown that also list this particular person/team.
- Adds a section called "Documentation" to our service view. When clicking on an entry, the respective URL is opened in a new browser tab.
- Adds enhancements to the general UI design.

Regarding the last point: When implementing the "Responsibles" feature, I noticed that it was kinda hard for the eye to follow which items actually belong to the "Responsibles", and which items are part of the next data group. So I decided to add some visual grouping by adding a pretty prominent shadow, creating a card-like effect. Also, I swapped some h3 to h4 tags so that the headings are not too big. (I know that this is semantically not correct, but I guess this should be fine for now.)

Before | After 
--- | --- 
![grafik](https://user-images.githubusercontent.com/8061217/201477842-c42a701c-b559-4ec7-89c5-7f34a27823a4.png) | ![grafik](https://user-images.githubusercontent.com/8061217/201477643-b330e78f-6014-4330-b0ae-8ba91850fd29.png) 
![grafik](https://user-images.githubusercontent.com/8061217/201478056-4c4b93da-97e7-4776-add5-2c6583a194e9.png) | ![grafik](https://user-images.githubusercontent.com/8061217/201478079-820f408c-5f63-4135-8333-c258e1e6cda8.png)



# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/201477620-4c11aad9-b632-45f8-87e2-1e83684ed99c.png)
![grafik](https://user-images.githubusercontent.com/8061217/201477626-1e147079-7d6d-45ed-94e5-f716376a5b34.png)
![grafik](https://user-images.githubusercontent.com/8061217/201477643-b330e78f-6014-4330-b0ae-8ba91850fd29.png)
![grafik](https://user-images.githubusercontent.com/8061217/201477647-d8359707-dc1e-4cd5-805f-7fe63842b804.png)
![grafik](https://user-images.githubusercontent.com/8061217/201477659-bbde6584-f450-408d-86db-186ee27a3944.png)



