### PR TITLE
Implement filtering

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,6 +47,23 @@ jobs:
       - name: Run the linter
         run: npm run lint
 
+  test:
+    name: Test everything
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run the tests
+        run: npm test
+
   build:
     name: Build everything
 

--- a/client-generated/package.json
+++ b/client-generated/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "rimraf dist/ && tsc",
     "prepare": "npm run build",
-    "lint": "echo 'Ignoring the lint command in client-generated'"
+    "lint": "echo 'Ignoring the lint command in client-generated'",
+    "test": "echo 'Ignoring the test command in client-generated'"
   }
 }

--- a/client-generator/package.json
+++ b/client-generator/package.json
@@ -9,7 +9,8 @@
     "generate": "npm run generate:ts-rxjs",
     "generate:ts-rxjs": "openapi-generator-cli generate --generator-key=ts-rxjs",
     "build": "echo 'Ignoring the build command in client-generator'",
-    "lint": "echo 'Ignoring the lint command in client-generator'"
+    "lint": "echo 'Ignoring the lint command in client-generator'",
+    "test": "echo 'Ignoring the test command in client-generator'"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.5.2"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,11 @@ Open [http://localhost:3001](http://localhost:3001) to view it in the browser.
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 
+### `npm test`
+
+Launches the test runner in the interactive watch mode.\
+See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.\

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,6 +16,10 @@ You will also see any lint errors in the console.
 
 ### `npm test`
 
+Launches the test runner. Unlike in the default CreateReactApp setup, this does not launch the tests in interactive mode. Use `npm run test-interactive` if you want to run the tests in interactive mode.
+
+### `npm run test-interactive`
+
 Launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "@mui/lab": "^5.0.0-alpha.108",
     "@mui/material": "^5.10.14",
     "@nivo/sankey": "^0.80.0",
+    "escape-string-regexp": "^5.0.0",
+    "ohm-js": "^16.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src --max-warnings=0"
   },
@@ -25,6 +26,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.9",
     "sass": "^1.56.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
+    "test-interactive": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src --max-warnings=0"
   },

--- a/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-modal.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/common/dependencies/visualization/visualization-modal.tsx
@@ -160,9 +160,9 @@ interface SankeyNodeWithDepth extends CustomSankeyNode {
   depth: number;
 }
 function getNodeAlignment(node: SankeyNodeWithDepth, maxDepth: number): number {
-  // Important: It is possible that the diagram has less than 3 columns (e.g. if there are no source nodes). This makes it hard to determine where a particular node shall be positioned. To solve this issue for now, we simply use the node depth. This is probably not ideal (it could produce unexpected alignments). However, this should be fine for now given that most of our diagrams contain enough data to produce 3-column layouts.
+  // Important: It is possible that the diagram has less than 3 columns (e.g. if there are no source nodes). This makes it hard to determine where a particular node shall be positioned. To solve this issue for now, we simply use the node depth. This is probably not ideal (it could produce unexpected alignments). However, this should be fine for now given that most of our diagrams contain enough data to produce 3-column layouts. Also, please note that, for some reason, the total depth (i.e. maxDepth) is defined as "one plus the maximum node.depth". So we know that, for instance, maxDepth===2 means that we have 2 columns.
 
-  if (maxDepth < 2) {
+  if (maxDepth < 3) {
     return node.depth;
   }
 

--- a/frontend/src/components/main-page/groups-tree-page/filter/apply-filter.ts
+++ b/frontend/src/components/main-page/groups-tree-page/filter/apply-filter.ts
@@ -1,0 +1,131 @@
+import escapeStringRegexp from 'escape-string-regexp';
+
+import { ServiceNode } from '../../service-docs-tree';
+
+import {
+  AndNode,
+  FilterNode,
+  FilterNodeType,
+  LiteralNode,
+  NotNode,
+  OrNode,
+  QUERY_KEY_TO_SERVICEDOC_MAP,
+  SPECIAL_EMPTY_TAG,
+} from './models';
+
+export function applyFilter(
+  filter: FilterNode,
+  serviceDocs: ServiceNode[],
+): ServiceNode[] {
+  const result: ServiceNode[] = [];
+
+  for (const singleServiceDoc of serviceDocs) {
+    if (doesServiceDocMatchFilter(filter, singleServiceDoc)) {
+      result.push(singleServiceDoc);
+    }
+  }
+
+  return result;
+}
+
+function doesServiceDocMatchFilter(
+  filter: FilterNode,
+  serviceDoc: ServiceNode,
+): boolean {
+  switch (filter.type) {
+    case FilterNodeType.And:
+      return doesMatchAndNode(filter, serviceDoc);
+    case FilterNodeType.Or:
+      return doesMatchOrNode(filter, serviceDoc);
+    case FilterNodeType.Not:
+      return doesMatchNotNode(filter, serviceDoc);
+    case FilterNodeType.Literal:
+      return doesMatchLiteralNode(filter, serviceDoc);
+  }
+}
+
+function doesMatchAndNode(filter: AndNode, serviceDoc: ServiceNode): boolean {
+  if (!doesServiceDocMatchFilter(filter.leftChild, serviceDoc)) {
+    return false;
+  }
+  return doesServiceDocMatchFilter(filter.rightChild, serviceDoc);
+}
+function doesMatchOrNode(filter: OrNode, serviceDoc: ServiceNode): boolean {
+  if (doesServiceDocMatchFilter(filter.leftChild, serviceDoc)) {
+    return true;
+  }
+  return doesServiceDocMatchFilter(filter.rightChild, serviceDoc);
+}
+function doesMatchNotNode(filter: NotNode, serviceDoc: ServiceNode): boolean {
+  return !doesServiceDocMatchFilter(filter.child, serviceDoc);
+}
+
+function doesMatchLiteralNode(
+  filter: LiteralNode,
+  serviceDoc: ServiceNode,
+): boolean {
+  const serviceDocKey = QUERY_KEY_TO_SERVICEDOC_MAP[filter.key];
+  if (serviceDocKey !== undefined) {
+    // We use the raw Service Doc here, because there are less different types we need to distinguish compared to the processed ones in the containing Service Doc.
+    const serviceDocEntry = serviceDoc.rawData[serviceDocKey];
+    return doesEntryMatchFilter(filter, serviceDocEntry);
+  }
+
+  console.warn('An invalid filter has been applied', filter);
+  return false;
+}
+function doesEntryMatchFilter(
+  filter: LiteralNode,
+  serviceDocEntry: unknown,
+): boolean {
+  if (filter.value.toLowerCase() === SPECIAL_EMPTY_TAG) {
+    if (serviceDocEntry === undefined) {
+      return true;
+    }
+    if (serviceDocEntry === '') {
+      return true;
+    }
+    if (Array.isArray(serviceDocEntry) && serviceDocEntry.length < 1) {
+      return true;
+    }
+    return false;
+  }
+
+  if (typeof serviceDocEntry === 'string') {
+    return isStringMatching(serviceDocEntry, filter.value);
+  }
+
+  if (isStringArray(serviceDocEntry)) {
+    for (const singleEntry of serviceDocEntry) {
+      if (isStringMatching(singleEntry, filter.value)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isStringArray(element: unknown): element is string[] {
+  if (!Array.isArray(element)) {
+    return false;
+  }
+
+  for (const singleEntry of element) {
+    if (typeof singleEntry !== 'string') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isStringMatching(theString: string, theQuery: string): boolean {
+  // Escape the query so that special characters don't have an unintended side effect.
+  let preparedQuery = escapeStringRegexp(theQuery);
+  // There is one special case: We want to allow wildcards with the "*" character. So: "un-escape" this character and replace it with a proper Regex wildcard.
+  preparedQuery = preparedQuery.replaceAll('\\*', '.*');
+
+  const regex = new RegExp(preparedQuery, 'i');
+  return regex.test(theString);
+}

--- a/frontend/src/components/main-page/groups-tree-page/filter/filter-dialog.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/filter/filter-dialog.tsx
@@ -1,0 +1,111 @@
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Box } from '@mui/system';
+import React from 'react';
+
+import { FilterNode } from './models';
+import { parseFilterQuery } from './parse-query';
+
+interface Props {
+  currentRawFilterQuery: string | undefined;
+
+  applyFilter: (filter: FilterNode, rawQuery: string) => void;
+  removeFilter: () => void;
+  close: () => void;
+}
+export const FilterDialog: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <Dialog maxWidth={false} open onClose={(): void => props.close()}>
+      <DialogContent sx={{ width: '900px', maxWidth: '100%' }}>
+        <Typography variant="h4">Filter</Typography>
+
+        {controller.state.showInfoAboutInvalidFilterQuery && (
+          <Alert sx={{ marginTop: 2 }} severity="error">
+            The filter query is invalid.
+          </Alert>
+        )}
+
+        <Box sx={{ marginTop: 2 }}>
+          <form
+            onSubmit={(e): void => {
+              e.preventDefault();
+              controller.applyOrRemoveFilter();
+            }}
+          >
+            <TextField
+              sx={{ width: '100%' }}
+              label="Filter Query"
+              value={controller.state.filterQuery}
+              onChange={(e): void => controller.setFilterQuery(e.target.value)}
+            />
+          </form>
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={(): void => props.close()}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={(): void => controller.applyOrRemoveFilter()}
+        >
+          Apply Filter
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+interface State {
+  filterQuery: string;
+
+  showInfoAboutInvalidFilterQuery: boolean;
+}
+interface Controller {
+  state: State;
+
+  setFilterQuery: (query: string) => void;
+
+  applyOrRemoveFilter: () => void;
+}
+function useController(props: Props): Controller {
+  const [state, setState] = React.useState<State>({
+    filterQuery: props.currentRawFilterQuery ?? '',
+
+    showInfoAboutInvalidFilterQuery: false,
+  });
+
+  return {
+    state: state,
+
+    setFilterQuery: (query): void => {
+      setState((state) => ({ ...state, filterQuery: query }));
+    },
+
+    applyOrRemoveFilter: (): void => {
+      if (state.filterQuery.trim() === '') {
+        props.removeFilter();
+        return;
+      }
+
+      const filterQueryParseResult = parseFilterQuery(state.filterQuery);
+      if (!filterQueryParseResult.success) {
+        setState((state) => ({
+          ...state,
+          showInfoAboutInvalidFilterQuery: true,
+        }));
+        return;
+      }
+
+      props.applyFilter(filterQueryParseResult.data, state.filterQuery);
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/filter/index.ts
+++ b/frontend/src/components/main-page/groups-tree-page/filter/index.ts
@@ -1,0 +1,3 @@
+export type { FilterNode } from './models';
+export { applyFilter } from './apply-filter';
+export { FilterDialog } from './filter-dialog';

--- a/frontend/src/components/main-page/groups-tree-page/filter/models.ts
+++ b/frontend/src/components/main-page/groups-tree-page/filter/models.ts
@@ -1,0 +1,75 @@
+import { GetServiceDocResponse } from 'msadoc-client';
+
+export type FilterNode = AndNode | OrNode | NotNode | LiteralNode;
+
+export enum FilterNodeType {
+  Literal,
+  And,
+  Or,
+  Not,
+}
+
+export interface AndNode {
+  type: FilterNodeType.And;
+
+  leftChild: FilterNode;
+  rightChild: FilterNode;
+}
+export interface OrNode {
+  type: FilterNodeType.Or;
+
+  leftChild: FilterNode;
+  rightChild: FilterNode;
+}
+export interface NotNode {
+  type: FilterNodeType.Not;
+  child: FilterNode;
+}
+export interface LiteralNode {
+  type: FilterNodeType.Literal;
+  key: string;
+  value: string;
+}
+
+type QueryKeyToServiceDocKeyMap = Record<string, keyof GetServiceDocResponse>;
+
+/**
+ * In the filter queries, the allowed keys (slightly) differ from the keys that are present in the Service Docs.
+ * For instance, we use "tag" instead of "tags" in the queries to better match the idea that we match a single tag.
+ * This Map maps from a filter key to the respective Service Doc key.
+ *
+ * **IMPORTANT**: The keys must all be lowercase, because in our Semantics, we use ".toLowerCase()".
+ */
+export const QUERY_KEY_TO_SERVICEDOC_MAP: QueryKeyToServiceDocKeyMap = {
+  name: 'name',
+  tag: 'tags',
+  group: 'group',
+  repository: 'repository',
+  taskboard: 'taskBoard',
+
+  providedapi: 'providedAPIs',
+  consumedapi: 'consumedAPIs',
+  publishedevent: 'publishedEvents',
+  subscribedevent: 'subscribedEvents',
+
+  developmentdocumentation: 'developmentDocumentation',
+  deploymentdocumentation: 'deploymentDocumentation',
+  apidocumentation: 'apiDocumentation',
+
+  responsibleteam: 'responsibleTeam',
+  responsible: 'responsibles',
+};
+
+/**
+ * The strings that are allowed to be used as keys in a query.
+ */
+export const allowedLiteralNodeKeys = Object.keys(QUERY_KEY_TO_SERVICEDOC_MAP);
+
+/**
+ * In a query, one can write `%empty%` in order to match empty values.
+ * A value is considered empty if:
+ * - It is missing in the Service Doc.
+ * - It is the empty string.
+ * - It is an empty array.
+ */
+export const SPECIAL_EMPTY_TAG = '%empty%';

--- a/frontend/src/components/main-page/groups-tree-page/filter/parse-query.test.ts
+++ b/frontend/src/components/main-page/groups-tree-page/filter/parse-query.test.ts
@@ -1,0 +1,266 @@
+import { FilterNode, FilterNodeType } from './models';
+import { parseFilterQuery } from './parse-query';
+
+interface TestExpectedToSucceed {
+  testDescription: string;
+  query: string;
+  expectedResult: FilterNode;
+}
+
+const TESTS_EXPECTED_TO_SUCCEED: TestExpectedToSucceed[] = [
+  {
+    testDescription: 'should parse a single key-value pair',
+    query: 'name:foo',
+    expectedResult: { type: FilterNodeType.Literal, key: 'name', value: 'foo' },
+  },
+  {
+    testDescription: 'should allow whitespace in quotes',
+    query: 'name:"foo bar"',
+    expectedResult: {
+      type: FilterNodeType.Literal,
+      key: 'name',
+      value: 'foo bar',
+    },
+  },
+  {
+    testDescription: 'should allow special characters',
+    query: 'name:foo-_*&baz',
+    expectedResult: {
+      type: FilterNodeType.Literal,
+      key: 'name',
+      value: 'foo-_*&baz',
+    },
+  },
+  {
+    testDescription: 'should properly treat an explicit "AND"',
+    query: 'name:foo AND tag:bar',
+    expectedResult: {
+      type: FilterNodeType.And,
+      leftChild: {
+        type: FilterNodeType.Literal,
+        key: 'name',
+        value: 'foo',
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+  {
+    testDescription: 'should properly treat an implicit "AND"',
+    query: 'name:foo tag:bar',
+    expectedResult: {
+      type: FilterNodeType.And,
+      leftChild: {
+        type: FilterNodeType.Literal,
+        key: 'name',
+        value: 'foo',
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+  {
+    testDescription: 'should properly treat an "OR"',
+    query: 'name:foo OR tag:bar',
+    expectedResult: {
+      type: FilterNodeType.Or,
+      leftChild: {
+        type: FilterNodeType.Literal,
+        key: 'name',
+        value: 'foo',
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+  {
+    testDescription: 'should properly treat a "NOT"',
+    query: 'NOT name:foo',
+    expectedResult: {
+      type: FilterNodeType.Not,
+      child: {
+        type: FilterNodeType.Literal,
+        key: 'name',
+        value: 'foo',
+      },
+    },
+  },
+  {
+    testDescription: 'should bind "NOT" tighter than "AND"',
+    query: 'NOT name:foo AND tag:bar',
+    expectedResult: {
+      type: FilterNodeType.And,
+      leftChild: {
+        type: FilterNodeType.Not,
+        child: {
+          type: FilterNodeType.Literal,
+          key: 'name',
+          value: 'foo',
+        },
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+  {
+    testDescription: 'should bind "AND" tighter than "OR"',
+    query: 'tag:baz OR name:foo AND tag:bar',
+    expectedResult: {
+      type: FilterNodeType.Or,
+      leftChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'baz',
+      },
+      rightChild: {
+        type: FilterNodeType.And,
+        leftChild: {
+          type: FilterNodeType.Literal,
+          key: 'name',
+          value: 'foo',
+        },
+        rightChild: {
+          type: FilterNodeType.Literal,
+          key: 'tag',
+          value: 'bar',
+        },
+      },
+    },
+  },
+  {
+    testDescription:
+      'should properly handle brackets to explicitly define the operator precedence',
+    query: '(tag:baz OR name:foo) AND tag:bar',
+    expectedResult: {
+      type: FilterNodeType.And,
+      leftChild: {
+        type: FilterNodeType.Or,
+        leftChild: {
+          type: FilterNodeType.Literal,
+          key: 'tag',
+          value: 'baz',
+        },
+        rightChild: {
+          type: FilterNodeType.Literal,
+          key: 'name',
+          value: 'foo',
+        },
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+
+  // Tests regarding additional spaces and the like.
+
+  {
+    testDescription: 'should successfully parse if there are additional spaces',
+    query: '  name  : foo         AND       tag: bar',
+    expectedResult: {
+      type: FilterNodeType.And,
+      leftChild: {
+        type: FilterNodeType.Literal,
+        key: 'name',
+        value: 'foo',
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+  {
+    testDescription: 'should successfully parse if a lowercase "AND" is used',
+    query: 'name:foo and tag:bar',
+    expectedResult: {
+      type: FilterNodeType.And,
+      leftChild: {
+        type: FilterNodeType.Literal,
+        key: 'name',
+        value: 'foo',
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+  {
+    testDescription:
+      'should successfully parse if keys use uppercase characters',
+    query: 'NamE:foo and TAG:bar',
+    expectedResult: {
+      type: FilterNodeType.And,
+      leftChild: {
+        type: FilterNodeType.Literal,
+        key: 'name',
+        value: 'foo',
+      },
+      rightChild: {
+        type: FilterNodeType.Literal,
+        key: 'tag',
+        value: 'bar',
+      },
+    },
+  },
+];
+
+interface TestExpectedToFail {
+  testDescription: string;
+  query: string;
+}
+
+const TESTS_EXPECTED_TO_FAIL: TestExpectedToFail[] = [
+  {
+    testDescription: 'should fail when trying to parse an empty string',
+    query: '',
+  },
+  {
+    testDescription: 'should fail when trying to parse a key without a value',
+    query: 'name:foo tag:',
+  },
+  {
+    testDescription: 'should fail when trying to use an unknown key',
+    query: 'foo:bar',
+  },
+  {
+    testDescription: 'should fail when using empty brackets',
+    query: 'foo:bar AND ()',
+  },
+];
+
+for (const singleTest of TESTS_EXPECTED_TO_SUCCEED) {
+  it(`${singleTest.testDescription} (query: "${singleTest.query}")`, () => {
+    const parseResult = parseFilterQuery(singleTest.query);
+    expect(parseResult.success).toEqual(true);
+    if (!parseResult.success) {
+      return;
+    }
+
+    expect(parseResult.data).toEqual(singleTest.expectedResult);
+  });
+}
+
+for (const singleTest of TESTS_EXPECTED_TO_FAIL) {
+  it(`${singleTest.testDescription} (query: "${singleTest.query}")`, () => {
+    const parseResult = parseFilterQuery(singleTest.query);
+    expect(parseResult.success).toEqual(false);
+  });
+}

--- a/frontend/src/components/main-page/groups-tree-page/filter/parse-query.ts
+++ b/frontend/src/components/main-page/groups-tree-page/filter/parse-query.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
+import ohm from 'ohm-js';
+
+import { Result } from '../../../../models/result';
+
+import { FilterNode, FilterNodeType, allowedLiteralNodeKeys } from './models';
+
+/*
+  Regarding operator precedence:
+  We want "NOT" to bind tighter than "AND". And we want "AND" to bind tighter than "OR".
+  To achieve this, we follow the idea of the Ohm example regarding math arithmetics, which basically says that the weaker binding operators should come first and "call" the stronger-binding ones.
+  In the math example, the following is defined:
+  Exp
+    = AddExp
+
+  AddExp
+    = AddExp "+" MulExp  -- plus
+    | AddExp "-" MulExp  -- minus
+    | MulExp
+
+  MulExp
+    = MulExp "*" ExpExp  -- times
+    | MulExp "/" ExpExp  -- divide
+    | ExpExp
+
+  Here, we use the same structure, but of course with "OR", "AND", and "NOT".
+*/
+
+const allowedKeysPreparedForGrammar = allowedLiteralNodeKeys.map(
+  (singleKey) => `caseInsensitive<"${singleKey}">`,
+);
+
+const grammarSource = String.raw`
+  MyGrammar {
+    Exp 
+      = OrExpression
+
+    OrExpression 
+      = OrExpression caseInsensitive<"OR"> AndExpression -- recurse
+      | AndExpression                                    -- passthrough
+
+    AndExpression 
+      = AndExpression caseInsensitive<"AND"> NotExpression -- recurseWithExplicitAnd
+      | AndExpression NotExpression                        -- recurseWithImplicitAnd
+      | NotExpression                                      -- passthrough
+
+    NotExpression 
+      = caseInsensitive<"NOT"> SingleExpression -- default
+      | SingleExpression                        -- passthrough
+
+    SingleExpression 
+      = "(" Exp ")"                                   -- brackets
+      | SingleExpressionKey ":" SingleExpressionValue -- default
+
+    SingleExpressionKey 
+      = ${allowedKeysPreparedForGrammar.join('|')}
+
+    SingleExpressionValue 
+      = SingleExpressionValueWithoutQuotes | SingleExpressionValueWithQuotes
+
+    // A value that is not enclosed in double quotes. We allow any string that does not contain double quotes, round brackets, or spaces.
+    SingleExpressionValueWithoutQuotes 
+      = #((~"\"" ~"(" ~")" ~space any)+)
+
+    // A value that is enclosed in double quotes. We allow any string within this (except for double quotes of course, since they terminate this string).
+    SingleExpressionValueWithQuotes 
+      = #("\""(~"\"" any)+"\"")
+  }
+  `;
+
+const grammar = ohm.grammar(grammarSource);
+
+const semantics = grammar
+  .createSemantics()
+  .addOperation<FilterNode | string>('eval', {
+    Exp(a): FilterNode {
+      return a.eval();
+    },
+    OrExpression_recurse(a, _b, c): FilterNode {
+      return {
+        type: FilterNodeType.Or,
+        leftChild: a.eval(),
+        rightChild: c.eval(),
+      };
+    },
+    OrExpression_passthrough(a): FilterNode {
+      return a.eval();
+    },
+    AndExpression_recurseWithExplicitAnd(a, _b, c): FilterNode {
+      return {
+        type: FilterNodeType.And,
+        leftChild: a.eval(),
+        rightChild: c.eval(),
+      };
+    },
+    AndExpression_recurseWithImplicitAnd(a, b): FilterNode {
+      return {
+        type: FilterNodeType.And,
+        leftChild: a.eval(),
+        rightChild: b.eval(),
+      };
+    },
+    AndExpression_passthrough(a): FilterNode {
+      return a.eval();
+    },
+    NotExpression_default(_a, b): FilterNode {
+      return {
+        type: FilterNodeType.Not,
+        child: b.eval(),
+      };
+    },
+    NotExpression_passthrough(a): FilterNode {
+      return a.eval();
+    },
+    SingleExpression_brackets(_a, b, _c): FilterNode {
+      return b.eval();
+    },
+    SingleExpression_default(a, _b, c): FilterNode {
+      return {
+        type: FilterNodeType.Literal,
+        key: a.eval(),
+        value: c.eval(),
+      };
+    },
+    SingleExpressionKey(a): string {
+      // We use ".toLowerCase()" because we allow users to also use uppercase keys.
+      return a.sourceString.toLowerCase();
+    },
+    SingleExpressionValue(a): string {
+      return a.eval();
+    },
+    SingleExpressionValueWithoutQuotes(a): string {
+      return a.sourceString;
+    },
+    SingleExpressionValueWithQuotes(_a, b, _c): string {
+      return b.sourceString;
+    },
+  });
+
+export function parseFilterQuery(query: string): Result<FilterNode> {
+  const matchResult = grammar.match(query);
+  if (!matchResult.succeeded()) {
+    return { success: false };
+  }
+
+  const filterTree = semantics(matchResult).eval();
+
+  return {
+    success: true,
+    data: filterTree,
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
@@ -1,27 +1,149 @@
-import { Box } from '@mui/material';
+import { Alert, Box, Divider, IconButton } from '@mui/material';
+import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
 
+import { Icons } from '../../../icons';
+import {
+  ServiceDocsServiceContextProvider,
+  useServiceDocsServiceContext,
+} from '../services/service-docs-service';
+
+import { FilterDialog, FilterNode, applyFilter } from './filter';
 import { GroupsTreePageRouter } from './router';
 import { Tree } from './tree';
 
 export const GroupsTreePage: React.FC = () => {
-  return (
-    <Box sx={{ height: '100%', overflow: 'hidden', display: 'flex' }}>
-      <Box
-        sx={{
-          height: '100%',
-          overflow: 'auto',
-          width: '300px',
-          flexShrink: 0,
-          background: (theme) => theme.palette.grey[100],
-        }}
-      >
-        <Tree />
-      </Box>
+  const controller = useController();
 
-      <Box sx={{ height: '100%', overflow: 'auto', flexGrow: 1 }}>
-        <GroupsTreePageRouter />
-      </Box>
-    </Box>
+  return (
+    <React.Fragment>
+      {/*
+        Here, we override the ServiceDocsService context with a new one that only contains the filtered services.
+        This allows us to just "blindly" access the ServiceDocsService in the entire page without having to distinguish between "all services" and "filtered services".
+      */}
+      <ServiceDocsServiceContextProvider
+        serviceDocs={controller.state.filteredServiceDocs}
+      >
+        <Box sx={{ height: '100%', overflow: 'hidden', display: 'flex' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+
+              height: '100%',
+              overflow: 'hidden',
+              width: '300px',
+              flexShrink: 0,
+              background: (theme) => theme.palette.grey[100],
+            }}
+          >
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <IconButton
+                onClick={(): void => controller.setShowFilterDialog(true)}
+              >
+                <Icons.FilterAlt />
+              </IconButton>
+            </Box>
+
+            <Divider />
+
+            <Box sx={{ overflow: 'auto', minWidth: 0, flexGrow: 1 }}>
+              {controller.state.rawFilterQuery !== undefined && (
+                <Alert severity="info">The filter is active</Alert>
+              )}
+
+              {controller.state.filteredServiceDocs.length > 0 ? (
+                <Tree />
+              ) : (
+                <Alert severity="warning">No Service Docs found</Alert>
+              )}
+            </Box>
+          </Box>
+
+          <Box sx={{ height: '100%', overflow: 'auto', flexGrow: 1 }}>
+            <GroupsTreePageRouter />
+          </Box>
+        </Box>
+      </ServiceDocsServiceContextProvider>
+
+      {controller.state.showFilterDialog && (
+        <FilterDialog
+          currentRawFilterQuery={controller.state.rawFilterQuery}
+          applyFilter={(filter: FilterNode, rawQuery: string): void => {
+            controller.applyFilter(filter, rawQuery);
+            controller.setShowFilterDialog(false);
+          }}
+          removeFilter={(): void => {
+            controller.removeFilter();
+            controller.setShowFilterDialog(false);
+          }}
+          close={(): void => controller.setShowFilterDialog(false)}
+        />
+      )}
+    </React.Fragment>
   );
 };
+
+interface State {
+  filteredServiceDocs: GetServiceDocResponse[];
+  rawFilterQuery: string | undefined;
+
+  showFilterDialog: boolean;
+}
+interface Controller {
+  state: State;
+
+  setShowFilterDialog: (show: boolean) => void;
+  applyFilter: (filter: FilterNode, rawQuery: string) => void;
+  removeFilter: () => void;
+}
+function useController(): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const [state, setState] = React.useState<State>(() => {
+    const rawServiceDocs = serviceDocsService.serviceDocs.map(
+      (singleServiceDoc) => singleServiceDoc.rawData,
+    );
+
+    return {
+      filteredServiceDocs: rawServiceDocs,
+      rawFilterQuery: undefined,
+      showFilterDialog: false,
+    };
+  });
+
+  return {
+    state: state,
+
+    setShowFilterDialog: (show): void => {
+      setState((state) => ({ ...state, showFilterDialog: show }));
+    },
+    applyFilter: (filter, rawQuery): void => {
+      const filteredServiceDocs = applyFilter(
+        filter,
+        serviceDocsService.serviceDocs,
+      );
+      const rawFilteredServiceDocs = filteredServiceDocs.map(
+        (singleServiceDoc) => singleServiceDoc.rawData,
+      );
+
+      setState((state) => ({
+        ...state,
+        filteredServiceDocs: rawFilteredServiceDocs,
+        rawFilterQuery: rawQuery,
+      }));
+    },
+
+    removeFilter: (): void => {
+      const allServiceDocs = serviceDocsService.serviceDocs.map(
+        (singleServiceDoc) => singleServiceDoc.rawData,
+      );
+
+      setState((state) => ({
+        ...state,
+        filteredServiceDocs: allServiceDocs,
+        rawFilterQuery: undefined,
+      }));
+    },
+  };
+}

--- a/frontend/src/components/main-page/groups-tree-page/router.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/router.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
+import {
+  Navigate,
+  RouteObject,
+  useNavigate,
+  useRoutes,
+} from 'react-router-dom';
 
 import {
   GROUPS_TREE_ROUTES_ABS,
   GROUPS_TREE_ROUTES_REL,
 } from '../../../routes';
+import { useSelectedTreeItem } from '../utils/router-utils';
 
 import { GroupDetails } from './group-details';
 import { ServiceDetails } from './service-details';
@@ -35,6 +41,15 @@ export const GroupsTreePageRouter: React.FC = () => {
     },
   ];
   const routeElement = useRoutes(routes);
+
+  const navigate = useNavigate();
+  const selectedTreeItem = useSelectedTreeItem();
+  // The tree item as found in the URL does not exist? Then navigate to the root.
+  React.useEffect(() => {
+    if (!selectedTreeItem) {
+      navigate(GROUPS_TREE_ROUTES_ABS.root);
+    }
+  }, [navigate, selectedTreeItem]);
 
   return <React.Fragment>{routeElement}</React.Fragment>;
 };

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -58,7 +58,7 @@ export const ServiceDetails: React.FC = () => {
                     <Icons.Group />
                   </ListItemIcon>
                   <ListItemText
-                    primary={controller.service.group.name}
+                    primary={controller.service.group.identifier}
                     secondary="Group"
                   />
                 </ListItem>

--- a/frontend/src/components/main-page/service-docs-tree.ts
+++ b/frontend/src/components/main-page/service-docs-tree.ts
@@ -37,6 +37,11 @@ export interface ServiceNode
   > {
   type: ServiceDocsTreeNodeType.Service;
 
+  /**
+   * The "raw" Service Doc as provided by the server.
+   */
+  rawData: GetServiceDocResponse;
+
   group: RegularGroupNode | RootGroupNode;
 
   providedAPIs: APINode[];
@@ -211,6 +216,8 @@ function buildAndInsertServiceItems(
 
     const newServiceDocNode: ServiceNode = {
       ...singleServiceDoc,
+
+      rawData: singleServiceDoc,
 
       type: ServiceDocsTreeNodeType.Service,
 

--- a/frontend/src/components/main-page/services/service-docs-service.tsx
+++ b/frontend/src/components/main-page/services/service-docs-service.tsx
@@ -31,7 +31,7 @@ function useServiceDocsService(
   };
 }
 
-const AuthDataServiceContext = React.createContext<
+const ServiceDocsServiceContext = React.createContext<
   ServiceDocsService | undefined
 >(undefined);
 
@@ -43,14 +43,14 @@ export const ServiceDocsServiceContextProvider: React.FC<Props> = (props) => {
   const serviceDocsService = useServiceDocsService(props.serviceDocs);
 
   return (
-    <AuthDataServiceContext.Provider value={serviceDocsService}>
+    <ServiceDocsServiceContext.Provider value={serviceDocsService}>
       {props.children}
-    </AuthDataServiceContext.Provider>
+    </ServiceDocsServiceContext.Provider>
   );
 };
 
 export const useServiceDocsServiceContext = (): ServiceDocsService => {
-  const context = React.useContext(AuthDataServiceContext);
+  const context = React.useContext(ServiceDocsServiceContext);
   if (!context) {
     throw Error(
       'Your component does not seem to be part of the ServiceDocsServiceContext!',

--- a/frontend/src/models/result.ts
+++ b/frontend/src/models/result.ts
@@ -1,0 +1,52 @@
+/**
+ * When dealing with function results, it is often very convenient to have a way to express success and failure.
+ * This type helps expressing success and failure.
+ *
+ * Example:
+ *
+ * ``` ts
+ * const result: Result<number> = {
+ *  success: true,
+ *  data: 123,
+ * }
+ * ```
+ *
+ * If the Generic is (potentially) `undefined`, the `data` field may be left out:
+ *
+ * ``` ts
+ * const result: Result<number | undefined> = {
+ *  success: true,
+ * }
+ * ```
+ *
+ */
+export type Result<SuccessData = undefined, ErrorData = undefined> =
+  | SuccessResult<SuccessData>
+  | ErrorResult<ErrorData>;
+
+export type SuccessResult<T = undefined> = T extends undefined
+  ? SuccessResultWithOptionalData<T>
+  : SuccessResultWithData<T>;
+
+export interface SuccessResultWithOptionalData<T> {
+  success: true;
+  data?: T;
+}
+export interface SuccessResultWithData<T> {
+  success: true;
+  data: T;
+}
+
+export type ErrorResult<T = undefined> = T extends undefined
+  ? ErrorResultWithOptionalData<T>
+  : ErrorResultWithData<T>;
+
+export interface ErrorResultWithOptionalData<T> {
+  success: false;
+  error?: T;
+}
+
+export interface ErrorResultWithData<T> {
+  success: false;
+  error: T;
+}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,6 @@
+/* eslint-disable capitalized-comments */
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "@mui/lab": "^5.0.0-alpha.108",
         "@mui/material": "^5.10.14",
         "@nivo/sankey": "^0.80.0",
+        "escape-string-regexp": "^5.0.0",
+        "ohm-js": "^16.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
@@ -63,6 +65,17 @@
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.9",
         "sass": "^1.56.1"
+      }
+    },
+    "frontend/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -13860,6 +13873,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
+    "node_modules/ohm-js": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-16.4.0.tgz",
+      "integrity": "sha512-u1QI5h2w29I4838+/m32rzqfNNH1Qej9L6O1MTZZMx7bVOu09orc/TO0HRVeYh5jStieZ3INszM7oqbCdx2x7A==",
+      "engines": {
+        "node": ">=0.12.1"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -31317,11 +31338,20 @@
         "@nivo/sankey": "^0.80.0",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.9",
+        "escape-string-regexp": "*",
+        "ohm-js": "^16.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
         "sass": "^1.56.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
       }
     },
     "msadoc-server": {
@@ -32387,6 +32417,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
+    "ohm-js": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-16.4.0.tgz",
+      "integrity": "sha512-u1QI5h2w29I4838+/m32rzqfNNH1Qej9L6O1MTZZMx7bVOu09orc/TO0HRVeYh5jStieZ3INszM7oqbCdx2x7A=="
     },
     "on-finished": {
       "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,9 @@
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^14.4.3",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.9",
         "sass": "^1.56.1"
@@ -77,6 +80,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
+      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -4784,6 +4793,141 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
+      "integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "5.16.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
+      "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.0.1",
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
+      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -4823,6 +4967,12 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "devOptional": true
+    },
+    "node_modules/@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -5369,6 +5519,15 @@
       "dev": true,
       "dependencies": {
         "@types/superagent": "*"
+      }
+    },
+    "node_modules/@types/testing-library__jest-dom": {
+      "version": "5.14.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
+      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -6552,6 +6711,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axe-core": {
@@ -8130,6 +8301,12 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
     "node_modules/cssdb": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.1.tgz",
@@ -8458,6 +8635,38 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="
     },
+    "node_modules/deep-equal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
+      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -8677,6 +8886,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+      "dev": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -8953,6 +9168,31 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
@@ -10094,6 +10334,15 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -10447,6 +10696,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -10907,6 +11168,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11001,6 +11271,22 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -11139,6 +11425,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -11240,6 +11535,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -11290,6 +11594,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -11307,12 +11630,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13284,6 +13629,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/macos-release": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
@@ -13434,6 +13788,15 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -13766,6 +14129,22 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -17270,6 +17649,19 @@
         "node": "*"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -18343,6 +18735,18 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -20044,6 +20448,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/windows-release": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-4.0.0.tgz",
@@ -21665,6 +22104,12 @@
     }
   },
   "dependencies": {
+    "@adobe/css-tools": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
+      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "dev": true
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -24792,6 +25237,112 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
+      "integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "aria-query": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+          "dev": true,
+          "requires": {
+            "deep-equal": "^2.0.5"
+          }
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.16.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
+      "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+      "dev": true,
+      "requires": {
+        "@adobe/css-tools": "^4.0.1",
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+          "dev": true,
+          "requires": {
+            "deep-equal": "^2.0.5"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
+      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
+      }
+    },
+    "@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "requires": {}
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -24825,6 +25376,12 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "devOptional": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -25334,6 +25891,15 @@
       "dev": true,
       "requires": {
         "@types/superagent": "*"
+      }
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.14.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
+      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
       }
     },
     "@types/trusted-types": {
@@ -26133,6 +26699,12 @@
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
       }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
     },
     "axe-core": {
       "version": "4.4.3",
@@ -27289,6 +27861,12 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
     "cssdb": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.1.tgz",
@@ -27553,6 +28131,37 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="
     },
+    "deep-equal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
+      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.8"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -27718,6 +28327,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -27936,6 +28551,30 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
     },
     "es-module-lexer": {
       "version": "0.9.3",
@@ -28773,6 +29412,15 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -29014,6 +29662,15 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -29331,6 +29988,12 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -29413,6 +30076,16 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -29499,6 +30172,12 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -29561,6 +30240,12 @@
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
       "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg=="
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true
+    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -29590,6 +30275,19 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -29601,12 +30299,28 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true
+    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "requires": {
         "call-bind": "^1.0.2"
+      }
+    },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "is-wsl": {
@@ -31140,6 +31854,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "dev": true
+    },
     "macos-release": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
@@ -31247,6 +31967,12 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "mini-css-extract-plugin": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
@@ -31336,9 +32062,12 @@
         "@mui/lab": "^5.0.0-alpha.108",
         "@mui/material": "^5.10.14",
         "@nivo/sankey": "^0.80.0",
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^14.4.3",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.9",
-        "escape-string-regexp": "*",
+        "escape-string-regexp": "^5.0.0",
         "ohm-js": "^16.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -32346,6 +33075,16 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
     },
     "object-keys": {
       "version": "1.1.1",
@@ -34734,6 +35473,16 @@
         }
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -35547,6 +36296,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -36724,6 +37482,32 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "windows-release": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces && npm run lint-additional-files",
     "lint-additional-files": "prettier --check **/*.{md,json,yaml,yml}"
   },


### PR DESCRIPTION
This PR is pretty huge. Its main purpose is to introduce filtering. While implementing this, I noticed a few small bugs/inconsistencies, which I decided to fix right away.

Filtering can be done using a custom "filter language". This probably needs a bit more explaination.

## Basics
Filter queries are written using `key:value` pairs such as `name:foo`. The `key` may be one of the following:

<details>

- name
- tag
- group
- repository
- taskboard
- providedapi
- consumedapi
- publishedevent
- subscribedevent
- developmentdocumentation
- deploymentdocumentation
- apidocumentation
- responsibleteam
- responsible

</details>

Casing does not matter, so for example `name:foo` and `NAME:foo` is equivalent.

You can use quotes if you need to use whitespace for a value: `name:"some name"`

Currently, the value is also case-insensitive. However, the parser preserves the casing. So in the future, it would be possible to implement case-sensitive queries. The keys on the other hand are all transformed to lowercase while parsing.

You can use wildcards like this: `name:something*`. The wildcard may appear multiple times, so you can also write: `name:*some*thing*` if you want to match anything that has the words "some" and "thing" in it. 

## The `%empty%` value

There is one special value called `%empty%`. This matches:
- Undefined values
- Empty strings
- Empty arrays

This is particularly useful if you want to show all Service Docs where a particular field is missing.

## Combining
These key-value pairs can be combined using `AND` and `OR`. For example, you can write `name:foo* AND tag:bar`. A shorthand for this is `name:foo* tag:bar`, i.e. if you omit the operator, then we use "AND".

There is also the `NOT` operator to negate something: `NOT name:foo`.

The operator precedence: `OR` < `AND` < `NOT`.

You can also use brackets:

```
name:foo* AND (tag:bar OR (tag:foo AND name:*baz))
```


## Examples
A few example queries:
- `name:someService`
- `name:*Service`
- `name:*Service AND tag:someTag` (equivalent to `name:*Service tag:someTag`)
- `name:*Service OR tag:someTag`
- `name:*Service OR NOT (tag:someTag AND providedAPI:*API* OR (consumedAPI:someAPI))`



# Screenshots
![grafik](https://user-images.githubusercontent.com/8061217/203846762-207cc618-09d7-4ffd-8c92-5d2c93288a53.png)
![grafik](https://user-images.githubusercontent.com/8061217/203846781-e1795b80-7259-4137-a203-5c6c0bdb283f.png)
![grafik](https://user-images.githubusercontent.com/8061217/203846796-9f66bb41-bc8e-454b-81a1-9b621f9d36ac.png)
![grafik](https://user-images.githubusercontent.com/8061217/203846808-41d0f467-4904-4df1-bb58-c90c09264085.png)
![grafik](https://user-images.githubusercontent.com/8061217/203846839-09a3a099-5e47-4c26-b47a-1667278b17fa.png)
![grafik](https://user-images.githubusercontent.com/8061217/203846951-4728e98b-eeea-436c-9dc7-1b14cfec1876.png)
![grafik](https://user-images.githubusercontent.com/8061217/203847020-c059db76-96c7-4f76-ae0f-95bb03640389.png)
![grafik](https://user-images.githubusercontent.com/8061217/203847049-0da2dd5f-b684-460b-b995-f85978bf0651.png)
![grafik](https://user-images.githubusercontent.com/8061217/203847112-e3b99130-4a75-4c3e-a497-05dc9edf441d.png)
![grafik](https://user-images.githubusercontent.com/8061217/203847123-e5febcf9-5a67-47fc-b2ca-24f08cffa8ba.png)

