### PR TITLE
Scroll the main content to the top when a different Tree Item is selected

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/groups-tree-page.tsx
@@ -60,8 +60,13 @@ export const GroupsTreePage: React.FC = () => {
             </Box>
           </Box>
 
-          <Box sx={{ height: '100%', overflow: 'auto', flexGrow: 1 }}>
-            <GroupsTreePageRouter />
+          <Box
+            ref={controller.mainContentRef}
+            sx={{ height: '100%', overflow: 'auto', flexGrow: 1 }}
+          >
+            <GroupsTreePageRouter
+              onChangeTreeItem={(): void => controller.scrollMainContentToTop()}
+            />
           </Box>
         </Box>
       </ServiceDocsServiceContextProvider>
@@ -93,6 +98,9 @@ interface State {
 interface Controller {
   state: State;
 
+  mainContentRef: React.RefObject<HTMLDivElement>;
+  scrollMainContentToTop: () => void;
+
   setShowFilterDialog: (show: boolean) => void;
   applyFilter: (filter: FilterNode, rawQuery: string) => void;
   removeFilter: () => void;
@@ -112,8 +120,15 @@ function useController(): Controller {
     };
   });
 
+  const mainContentRef = React.useRef<HTMLDivElement>(null);
+
   return {
     state: state,
+
+    mainContentRef: mainContentRef,
+    scrollMainContentToTop: (): void => {
+      mainContentRef.current?.scrollTo(0, 0);
+    },
 
     setShowFilterDialog: (show): void => {
       setState((state) => ({ ...state, showFilterDialog: show }));

--- a/frontend/src/components/main-page/groups-tree-page/router.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/router.tsx
@@ -15,7 +15,13 @@ import { useSelectedTreeItem } from '../utils/router-utils';
 import { GroupDetails } from './group-details';
 import { ServiceDetails } from './service-details';
 
-export const GroupsTreePageRouter: React.FC = () => {
+interface Props {
+  /**
+   * This function is called whenever the selected tree item changes (e.g. when a different service is selected).
+   */
+  onChangeTreeItem: () => void;
+}
+export const GroupsTreePageRouter: React.FC<Props> = (props) => {
   const routes: RouteObject[] = [
     {
       path: '/',
@@ -50,6 +56,11 @@ export const GroupsTreePageRouter: React.FC = () => {
       navigate(GROUPS_TREE_ROUTES_ABS.root);
     }
   }, [navigate, selectedTreeItem]);
+
+  // Whenever a new Tree Item is selected, call the function passed in Props.
+  React.useEffect(() => {
+    props.onChangeTreeItem();
+  }, [props, selectedTreeItem]);
 
   return <React.Fragment>{routeElement}</React.Fragment>;
 };

--- a/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/group-item.tsx
@@ -159,7 +159,7 @@ function useController(props: Props): Controller {
       return;
     }
 
-    buttonRef.current.scrollIntoView({ behavior: 'smooth' });
+    buttonRef.current.scrollIntoView({ block: 'nearest' });
   }, [isSelected]);
 
   // Automatically un-collapse this group if a child tree item gets selected using the Router.

--- a/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/root-item.tsx
@@ -87,7 +87,7 @@ function useController(): Controller {
       return;
     }
 
-    buttonRef.current.scrollIntoView({ behavior: 'smooth' });
+    buttonRef.current.scrollIntoView({ block: 'nearest' });
   }, [isSelected]);
 
   return {

--- a/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/tree/service-item.tsx
@@ -81,7 +81,7 @@ function useController(props: Props): Controller {
       return;
     }
 
-    buttonRef.current.scrollIntoView({ behavior: 'smooth' });
+    buttonRef.current.scrollIntoView({ block: 'nearest' });
   }, [isSelected]);
 
   return {


### PR DESCRIPTION
Currently, when a new service/group is selected, the main content (i.e. the part that displays the service/group details) is not scrolled to the top. This is pretty counter-intuitive: Normally, you expect that a page is scrolled to the top whenever you navigate to a new piece of content.

To try this out: Open any service (ideally one with a lot of content), scroll down, and then select another service (again ideally one with a lot of content). You will notice that the scroll position remains the same, which means that we basically "start in the middle of the service details".

This PR makes the main content scroll to the top whenever a new item is selected in the tree. Unfortunately, I had to disable smooth scrolling in the tree because of a Chrome bug, see https://stackoverflow.com/questions/49318497/google-chrome-simultaneously-smooth-scrollintoview-with-more-elements-doesn