### PR TITLE
Download graph image

### DIFF
--- a/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
+++ b/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { blue, grey, red, yellow } from '@mui/material/colors';
 import cytoscape, { ElementDefinition, Stylesheet } from 'cytoscape';
 import cola from 'cytoscape-cola';
@@ -60,6 +60,23 @@ export const DependencyGraph: React.FC = () => {
   const controller = useController();
   cytoscape.use(cola);
 
+  let cyInstance: cytoscape.Core | undefined;
+
+  const onDownload = async (): Promise<void> => {
+    if (cyInstance === undefined) {
+      return;
+    }
+    const pngBlob = await cyInstance.png({
+      output: 'blob-promise',
+    });
+
+    const fileName = 'msadoc-dependency-graph.png';
+    const downloadLink = document.createElement('a');
+    downloadLink.href = URL.createObjectURL(pngBlob);
+    downloadLink.download = fileName;
+    downloadLink.click();
+  };
+
   return (
     <React.Fragment>
       <Box
@@ -73,6 +90,16 @@ export const DependencyGraph: React.FC = () => {
           maxDepth={controller.state.maxGraphDepth}
           onChange={controller.updateGraphDepth}
         />
+        <Box height="auto" marginRight="auto" paddingTop="2em">
+          <Button
+            variant="contained"
+            onClick={(): void => {
+              void onDownload();
+            }}
+          >
+            Download PNG
+          </Button>
+        </Box>
       </Box>
 
       <Box
@@ -88,6 +115,7 @@ export const DependencyGraph: React.FC = () => {
           stylesheet={cyStyleSheets}
           cy={(cy): void => {
             cy.center();
+            cyInstance = cy;
           }}
         />
       </Box>

--- a/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
+++ b/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
@@ -16,45 +16,49 @@ import { useServiceDocsServiceContext } from '../services/service-docs-service';
 import { CyptoScapeBuilder } from './cytoscape-builder';
 import { DepthSlider } from './depth-slider';
 
-const cyLayout = {
-  name: 'cola',
-  nodeSpacing: (node: { data: (s: 'name') => string }): number => {
-    return node.data('name').length * 5; // Adapt spacing to name length
-  },
-  fit: false,
-  centerGraph: false,
-};
+function createCyLayout(): cytoscape.LayoutOptions {
+  return {
+    name: 'cola',
+    nodeSpacing: (node: { data: (s: 'name') => string }): number => {
+      return node.data('name').length * 5; // Adapt spacing to name length
+    },
+    fit: false,
+    centerGraph: false,
+  } as cytoscape.LayoutOptions;
+}
 
-const cyStyleSheets: Stylesheet[] = [
-  {
-    selector: 'node',
-    style: {
-      color: 'black',
-      label: 'data(name)',
-      'font-size': 20,
+function createCyStyleSheets(): Stylesheet[] {
+  return [
+    {
+      selector: 'node',
+      style: {
+        color: 'black',
+        label: 'data(name)',
+        'font-size': 20,
+      },
     },
-  },
-  {
-    selector: 'node[type = "group"]',
-    style: {
-      label: 'data(name)',
-      shape: 'rectangle',
-      'text-valign': 'top',
-      'text-halign': 'center',
-      'text-max-width': '100px',
-      'text-margin-y': 30,
-      'font-weight': 'bold',
-      'padding-top': '50px',
+    {
+      selector: 'node[type = "group"]',
+      style: {
+        label: 'data(name)',
+        shape: 'rectangle',
+        'text-valign': 'top',
+        'text-halign': 'center',
+        'text-max-width': '100px',
+        'text-margin-y': 30,
+        'font-weight': 'bold',
+        'padding-top': '50px',
+      },
     },
-  },
-  {
-    selector: 'edge',
-    style: {
-      'curve-style': 'bezier',
-      'target-arrow-shape': 'triangle',
+    {
+      selector: 'edge',
+      style: {
+        'curve-style': 'bezier',
+        'target-arrow-shape': 'triangle',
+      },
     },
-  },
-];
+  ];
+}
 
 export const DependencyGraph: React.FC = () => {
   const controller = useController();
@@ -101,9 +105,9 @@ export const DependencyGraph: React.FC = () => {
       >
         <CytoscapeComponent
           elements={controller.cyElements}
-          layout={cyLayout}
+          layout={createCyLayout()}
           style={{ width: '100%', height: '100%' }}
-          stylesheet={cyStyleSheets}
+          stylesheet={createCyStyleSheets()}
           cy={(cy): void => {
             cy.center();
             controller.cyRef.current = cy;

--- a/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
+++ b/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
@@ -90,7 +90,13 @@ export const DependencyGraph: React.FC = () => {
           maxDepth={controller.state.maxGraphDepth}
           onChange={controller.updateGraphDepth}
         />
-        <Box height="auto" marginRight="auto" paddingTop="2em">
+        <Box
+          sx={{
+            height: 'auto',
+            marginRight: 'auto',
+            paddingTop: '1rem',
+          }}
+        >
           <Button
             variant="contained"
             onClick={(): void => {

--- a/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
+++ b/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
@@ -88,7 +88,9 @@ export const DependencyGraph: React.FC = () => {
       >
         <DepthSlider
           maxDepth={controller.state.maxGraphDepth}
-          onChange={controller.updateGraphDepth}
+          onChange={(newDepth: number): void =>
+            controller.setState({ ...controller.state, graphDepth: newDepth })
+          }
         />
         <Box
           sx={{
@@ -137,7 +139,7 @@ interface State {
 interface Controller {
   state: State;
   cytoScapeElements: ElementDefinition[];
-  updateGraphDepth: (newDepth: number) => void;
+  setState: (newState: State) => void;
 }
 function useController(): Controller {
   const serviceDocsService = useServiceDocsServiceContext();
@@ -166,12 +168,7 @@ function useController(): Controller {
   return {
     cytoScapeElements: elements,
     state: state,
-    updateGraphDepth: (newDepth: number): void => {
-      setState({
-        graphDepth: newDepth,
-        maxGraphDepth: state.maxGraphDepth,
-      });
-    },
+    setState: setState,
   };
 }
 

--- a/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
+++ b/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
@@ -87,7 +87,7 @@ export const DependencyGraph: React.FC = () => {
         }}
       >
         <DepthSlider
-          maxDepth={controller.state.maxGraphDepth}
+          maxDepth={controller.maxGraphDepth}
           onChange={(newDepth: number): void =>
             controller.setState({ ...controller.state, graphDepth: newDepth })
           }
@@ -117,7 +117,7 @@ export const DependencyGraph: React.FC = () => {
         }}
       >
         <CytoscapeComponent
-          elements={controller.cytoScapeElements}
+          elements={controller.cyElements}
           layout={cyLayout}
           style={{ width: '100%', height: '100%' }}
           stylesheet={cyStyleSheets}
@@ -133,22 +133,24 @@ export const DependencyGraph: React.FC = () => {
 
 interface State {
   graphDepth: number;
-  maxGraphDepth: number;
 }
 
 interface Controller {
   state: State;
-  cytoScapeElements: ElementDefinition[];
+  maxGraphDepth: number;
+  cyElements: ElementDefinition[];
   setState: (newState: State) => void;
 }
 function useController(): Controller {
   const serviceDocsService = useServiceDocsServiceContext();
 
-  const maxDepth = getDepth(serviceDocsService.groupsTree);
+  const maxDepth = React.useMemo(
+    () => getDepth(serviceDocsService.groupsTree),
+    [serviceDocsService.groupsTree],
+  );
 
   const [state, setState] = React.useState<State>({
     graphDepth: maxDepth,
-    maxGraphDepth: maxDepth,
   });
 
   const elements = React.useMemo(
@@ -166,7 +168,8 @@ function useController(): Controller {
   );
 
   return {
-    cytoScapeElements: elements,
+    cyElements: elements,
+    maxGraphDepth: maxDepth,
     state: state,
     setState: setState,
   };


### PR DESCRIPTION
Closes #109.
Builds on #108. Only merge after!

Added a download button that downloads the current view of the dependency graph.
Better diff: https://github.com/osrgroup/msadoc/compare/105-configure-graph-depth...109-download-graph-image

## Screenshot
![image](https://user-images.githubusercontent.com/28054628/206227023-39685f9b-e70f-4e7c-8094-aec2d3706324.png)
