### PR TITLE
Add various improvements

### DIFF
--- a/frontend/src/components/login-page/login-page.tsx
+++ b/frontend/src/components/login-page/login-page.tsx
@@ -97,22 +97,12 @@ export const LoginPage: React.FC = () => {
 
                 {controller.state.viewState ===
                   ViewState.WrongUsernameOrPassword && (
-                  <Box
-                    sx={{
-                      color: (theme) => theme.palette.error.main,
-                    }}
-                  >
-                    Wrong username or password
-                  </Box>
+                  <Alert severity="error">Wrong username or password</Alert>
                 )}
                 {controller.state.viewState === ViewState.UnknownError && (
-                  <Box
-                    sx={{
-                      color: (theme) => theme.palette.error.main,
-                    }}
-                  >
+                  <Alert severity="error">
                     Unknown error, please try again
-                  </Box>
+                  </Alert>
                 )}
 
                 <TextField

--- a/frontend/src/components/main-page/graph-page/cytoscape-builder.ts
+++ b/frontend/src/components/main-page/graph-page/cytoscape-builder.ts
@@ -10,8 +10,8 @@ import {
   getDepthLevel,
 } from '../service-docs-tree';
 
-export interface ICyptoScapeBuilder {
-  fromGroup(group: RegularGroupNode | RootGroupNode): ICyptoScapeBuilder;
+export interface ICytoScapeBuilder {
+  fromGroup(group: RegularGroupNode | RootGroupNode): ICytoScapeBuilder;
   build(): ElementDefinition[];
 }
 
@@ -51,12 +51,12 @@ interface CytoScapeBuilderOptions {
   groupBackgroundColorFn: (groupNode: RegularGroupNode) => string;
 }
 
-export class CyptoScapeBuilder implements ICyptoScapeBuilder {
+export class CytoScapeBuilder implements ICytoScapeBuilder {
   elementDefinitions: ElementDefinition[] = [];
 
   constructor(private options: CytoScapeBuilderOptions) {}
 
-  fromGroup(group: RootGroupNode): CyptoScapeBuilder {
+  fromGroup(group: RootGroupNode): CytoScapeBuilder {
     for (const childGroup of Object.values(group.childGroups)) {
       this.addGroup(childGroup);
     }

--- a/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
+++ b/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
@@ -16,49 +16,45 @@ import { useServiceDocsServiceContext } from '../services/service-docs-service';
 import { CyptoScapeBuilder } from './cytoscape-builder';
 import { DepthSlider } from './depth-slider';
 
-function createCyLayout(): cytoscape.LayoutOptions {
-  return {
-    name: 'cola',
-    nodeSpacing: (node: { data: (s: 'name') => string }): number => {
-      return node.data('name').length * 5; // Adapt spacing to name length
-    },
-    fit: false,
-    centerGraph: false,
-  } as cytoscape.LayoutOptions;
-}
+const cyLayout = {
+  name: 'cola',
+  nodeSpacing: (node: { data: (s: 'name') => string }): number => {
+    return node.data('name').length * 5; // Adapt spacing to name length
+  },
+  fit: true,
+  centerGraph: true,
+} as cytoscape.LayoutOptions;
 
-function createCyStyleSheets(): Stylesheet[] {
-  return [
-    {
-      selector: 'node',
-      style: {
-        color: 'black',
-        label: 'data(name)',
-        'font-size': 20,
-      },
+const cyStyleSheets: Stylesheet[] = [
+  {
+    selector: 'node',
+    style: {
+      color: 'black',
+      label: 'data(name)',
+      'font-size': 20,
     },
-    {
-      selector: 'node[type = "group"]',
-      style: {
-        label: 'data(name)',
-        shape: 'rectangle',
-        'text-valign': 'top',
-        'text-halign': 'center',
-        'text-max-width': '100px',
-        'text-margin-y': 30,
-        'font-weight': 'bold',
-        'padding-top': '50px',
-      },
+  },
+  {
+    selector: 'node[type = "group"]',
+    style: {
+      label: 'data(name)',
+      shape: 'rectangle',
+      'text-valign': 'top',
+      'text-halign': 'center',
+      'text-max-width': '100px',
+      'text-margin-y': 30,
+      'font-weight': 'bold',
+      'padding-top': '50px',
     },
-    {
-      selector: 'edge',
-      style: {
-        'curve-style': 'bezier',
-        'target-arrow-shape': 'triangle',
-      },
+  },
+  {
+    selector: 'edge',
+    style: {
+      'curve-style': 'bezier',
+      'target-arrow-shape': 'triangle',
     },
-  ];
-}
+  },
+];
 
 export const DependencyGraph: React.FC = () => {
   const controller = useController();
@@ -105,11 +101,10 @@ export const DependencyGraph: React.FC = () => {
       >
         <CytoscapeComponent
           elements={controller.cyElements}
-          layout={createCyLayout()}
+          layout={cyLayout}
           style={{ width: '100%', height: '100%' }}
-          stylesheet={createCyStyleSheets()}
+          stylesheet={cyStyleSheets}
           cy={(cy): void => {
-            cy.center();
             controller.cyRef.current = cy;
           }}
         />

--- a/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
+++ b/frontend/src/components/main-page/graph-page/dependency-graph-view.tsx
@@ -13,7 +13,7 @@ import {
 } from '../service-docs-tree';
 import { useServiceDocsServiceContext } from '../services/service-docs-service';
 
-import { CyptoScapeBuilder } from './cytoscape-builder';
+import { CytoScapeBuilder } from './cytoscape-builder';
 import { DepthSlider } from './depth-slider';
 
 const cyLayout = {
@@ -150,7 +150,7 @@ function useController(): Controller {
 
   const elements = React.useMemo(
     () =>
-      new CyptoScapeBuilder({
+      new CytoScapeBuilder({
         depth: state.graphDepth,
         serviceBackgroundColorFn: () => red[600],
         groupBackgroundColorFn: getGroupColor,

--- a/frontend/src/components/main-page/groups-tree-page/router.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/router.tsx
@@ -60,7 +60,8 @@ export const GroupsTreePageRouter: React.FC<Props> = (props) => {
   // Whenever a new Tree Item is selected, call the function passed in Props.
   React.useEffect(() => {
     props.onChangeTreeItem();
-  }, [props, selectedTreeItem]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTreeItem]);
 
   return <React.Fragment>{routeElement}</React.Fragment>;
 };

--- a/frontend/src/models/api.ts
+++ b/frontend/src/models/api.ts
@@ -27,4 +27,4 @@ export type ListAllApiKeysHttpResponse = HttpResponse<
 >;
 
 export type CreateApiKeyResponse = HttpResponse<201, CreateApiKeyResponseDto>;
-export type DeleteSingleApiKeyResponse = HttpResponse<200, void>;
+export type DeleteSingleApiKeyResponse = HttpResponse<200, undefined>;

--- a/frontend/src/services/http/auth.tsx
+++ b/frontend/src/services/http/auth.tsx
@@ -11,7 +11,7 @@ import {
   useAuthDataServiceContext,
 } from '../auth-data-service';
 
-import { useHttpServiceContext } from './http-base';
+import { getErrorStatus, useHttpServiceContext } from './http-base';
 
 export interface AuthHttpService {
   /**
@@ -47,7 +47,7 @@ function useAuthHttpService(): AuthHttpService {
         data: response,
       };
     } catch (error) {
-      const errorStatus = httpService.getErrorStatus(error);
+      const errorStatus = getErrorStatus(error);
       return {
         status: errorStatus === 401 ? 401 : 0,
         data: undefined,
@@ -124,7 +124,7 @@ function useAuthHttpService(): AuthHttpService {
         refreshToken: response.refresh_token,
       };
     } catch (error) {
-      const errorStatus = httpService.getErrorStatus(error);
+      const errorStatus = getErrorStatus(error);
 
       if (errorStatus === 401) {
         authDataService.deleteAccessAndRefreshToken();
@@ -135,7 +135,7 @@ function useAuthHttpService(): AuthHttpService {
       // Something unexpected happened, e.g. the internet connection was lost.
       return undefined;
     }
-  }, [authDataService, doRefreshAuthToken, httpService, navigate]);
+  }, [authDataService, doRefreshAuthToken, navigate]);
 
   const TOKEN_REFRESH_INTERVAL_MS = 60000;
   // Whenever signed in, refresh the auth tokens regularly.

--- a/frontend/src/services/http/http-base.tsx
+++ b/frontend/src/services/http/http-base.tsx
@@ -1,15 +1,35 @@
 import { Configuration } from 'msadoc-client';
 import React from 'react';
+import { useNavigate } from 'react-router';
 import { AjaxConfig } from 'rxjs/ajax';
 
 import { ENVIRONMENT } from '../../env';
+import {
+  ErrorResultWithData,
+  SuccessResultWithData,
+} from '../../models/result';
+import { APP_ROUTES } from '../../routes';
+import { useAuthDataServiceContext } from '../auth-data-service';
+
+interface ErrorResponseResult {
+  httpStatus: number | undefined;
+}
 
 interface HttpService {
-  createConfiguration(accessToken?: string): Configuration;
-  getErrorStatus(error: unknown): number | undefined;
+  createConfiguration: (accessToken?: string) => Configuration;
+
+  performRegularApiRequest: <TSuccessResponseData>(
+    handler: (configuration: Configuration) => Promise<TSuccessResponseData>,
+  ) => Promise<
+    | SuccessResultWithData<TSuccessResponseData>
+    | ErrorResultWithData<ErrorResponseResult>
+  >;
 }
 
 function useHttpService(): HttpService {
+  const navigate = useNavigate();
+  const authDataService = useAuthDataServiceContext();
+
   function createConfiguration(accessToken?: string): Configuration {
     if (accessToken === undefined) {
       return new Configuration({
@@ -42,27 +62,76 @@ function useHttpService(): HttpService {
     });
   }
 
-  /**
-   * Get the "status" field of an error object returned when a http request fails.
-   */
-  function getErrorStatus(error: unknown): number | undefined {
-    if (typeof error !== 'object' || error == null) {
-      return undefined;
+  async function performRegularApiRequest<TSuccessResponseData>(
+    handler: (configuration: Configuration) => Promise<TSuccessResponseData>,
+  ): Promise<
+    | SuccessResultWithData<TSuccessResponseData>
+    | ErrorResultWithData<ErrorResponseResult>
+  > {
+    const accessToken =
+      authDataService.state.accessAndRefreshToken?.accessToken;
+    if (accessToken === undefined) {
+      navigate(APP_ROUTES.login);
+      return {
+        success: false,
+        error: {
+          httpStatus: undefined,
+        },
+      };
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-    const status = (error as any).status;
+    const configuration = createConfiguration(accessToken);
 
-    if (typeof status !== 'number') {
-      return undefined;
+    try {
+      const handlerResponse = await handler(configuration);
+
+      return {
+        success: true,
+        data: handlerResponse,
+      };
+    } catch (error) {
+      const errorStatus = getErrorStatus(error);
+
+      /*
+        We got a 401? 
+        At the moment, this always means that the used access token is, for some reason, invalid.
+        The server is currently not expected to return 401 when something else happens.
+      */
+      if (errorStatus === 401) {
+        authDataService.deleteAccessAndRefreshToken();
+        navigate(APP_ROUTES.login);
+      }
+
+      return {
+        success: false,
+        error: {
+          httpStatus: errorStatus,
+        },
+      };
     }
-    return status;
   }
 
   return {
     createConfiguration: createConfiguration,
-    getErrorStatus: getErrorStatus,
+    performRegularApiRequest: performRegularApiRequest,
   };
+}
+
+/**
+ * A helper function to get the "status" field of an error object returned when a http request fails.
+ */
+export function getErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error == null) {
+    return undefined;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+  const status = (error as any).status;
+
+  if (typeof status !== 'number') {
+    return undefined;
+  }
+  return status;
 }
 
 const HttpServiceContext = React.createContext<HttpService | undefined>(


### PR DESCRIPTION
This PR adds various small improvements:
- I have found duplicate code in the http services. There is now a function called `httpService.performRegularHttpRequest()` which takes care of this. *
- The design of the error message that is shown when a login fails is now improved: Originally, a red string would be shown, now we show a proper `<Alert />`.
- The PR also fixes a bug in the graph that would pull it to the center whenever `setState()` was called somewhere. **
- On our ServiceDocsDetails/GroupDetails page, we have a mechanism that scrolls the page to the top whenever the selected Service/Group changes. However, the page would sometimes be scrolled to the top even though the Service/Group did not change. This was because we listened for Props changes as well. I have fixed this to only listen for changes of the Service/Group.

--- 

\* The function is called "regularHttpRequest" because it should not be used for authentication purposes. Techically, it could of course be used for that, but it expects that an auth token exists and so on... So, it is meant to be used for almost all http request, hence the "regular" in the name.

\** I noticed this because from time to time, the graph would suddenly jump to a different position. I figured out that this was caused by our Auth service: It calls `setState()` roughly every 60 seconds. For testing, I set the timeout to 2 seconds. Then the following could be seen:



https://user-images.githubusercontent.com/8061217/207944100-385f91df-2e3f-4551-ae93-7520eaae9df8.mp4



