### PR TITLE
Show extension fields in the frontend

### DIFF
--- a/frontend/src/components/main-page/groups-tree-page/service-details/extension-fields.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/extension-fields.tsx
@@ -1,0 +1,95 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+
+import { ServiceNode } from '../../service-docs-tree';
+
+interface Props {
+  showExtensionFieldsFor: ServiceNode;
+}
+export const ExtensionFields: React.FC<Props> = (props) => {
+  return (
+    <React.Fragment>
+      {props.showExtensionFieldsFor.extensions && (
+        <React.Fragment>
+          <Typography variant="h4">Extensions</Typography>
+
+          <Table sx={{ tableLayout: 'fixed' }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Key</TableCell>
+                <TableCell>Value</TableCell>
+              </TableRow>
+            </TableHead>
+
+            <TableBody>
+              {Object.entries(props.showExtensionFieldsFor.extensions).map(
+                ([key, value]) => (
+                  <TableRow key={key}>
+                    <TableCell>{key}</TableCell>
+
+                    <TableCell>
+                      {Array.isArray(value) && (
+                        <React.Fragment>
+                          {value.length < 1 && <i>{`(Empty array)`}</i>}
+
+                          {value.length > 0 && (
+                            <ul>
+                              {value.map((singleArrayValue, index) => (
+                                // eslint-disable-next-line react/no-array-index-key
+                                <li key={index}>
+                                  <PrimitiveValue value={singleArrayValue} />
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </React.Fragment>
+                      )}
+
+                      {!Array.isArray(value) && (
+                        <PrimitiveValue value={value} />
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
+            </TableBody>
+          </Table>
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  );
+};
+
+interface PrimitiveValueProps {
+  value: string | number | boolean;
+}
+const PrimitiveValue: React.FC<PrimitiveValueProps> = (props) => {
+  return (
+    <span style={{ wordBreak: 'break-all' }}>
+      {typeof props.value === 'string' && (
+        <React.Fragment>
+          {props.value.trim() === '' ? (
+            <i>{`(Empty string)`}</i>
+          ) : (
+            <React.Fragment>{props.value}</React.Fragment>
+          )}
+        </React.Fragment>
+      )}
+
+      {typeof props.value === 'number' && (
+        <React.Fragment>{props.value}</React.Fragment>
+      )}
+
+      {typeof props.value === 'boolean' && (
+        <b>{props.value === true ? 'true' : 'false'}</b>
+      )}
+    </span>
+  );
+};

--- a/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
+++ b/frontend/src/components/main-page/groups-tree-page/service-details/service-details.tsx
@@ -18,6 +18,8 @@ import { Dependencies } from '../common/dependencies';
 import { Responsibilities } from '../common/responsibilities';
 import { Tags } from '../common/tags';
 
+import { ExtensionFields } from './extension-fields';
+
 export const ServiceDetails: React.FC = () => {
   const controller = useController();
 
@@ -179,6 +181,13 @@ export const ServiceDetails: React.FC = () => {
           <DataContainer>
             <Dependencies showDependenciesFor={controller.service} />
           </DataContainer>
+
+          {controller.service.extensions &&
+            Object.entries(controller.service.extensions).length > 0 && (
+              <DataContainer>
+                <ExtensionFields showExtensionFieldsFor={controller.service} />
+              </DataContainer>
+            )}
         </Box>
       )}
     </React.Fragment>


### PR DESCRIPTION
This PR adds the missing part from #18: Extension fields are now shown in the frontend (in a pretty generic way). If no extension fields are defined, then the card is not shown at all.

# Screenshot

![grafik](https://user-images.githubusercontent.com/8061217/208241064-4a20266f-981a-4278-9a1c-1f24e2bd88da.png)
