### PR TITLE
Switch to package-lock-utd

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
 
       - name: Check if package-lock.json is up to date
         run: npx --yes package-lock-utd@1.x.x
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,33 +3,6 @@ name: CI Pipeline
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  # The command 'npm ci' already does check whether the dependencies from package-lock.json are up-to-date with the ones from package.json. However, it seems like it ignores certain (small) differences, e.g. if we made small changes to package.json of a linked workspace project that does not influence the dependencies.
-  check-package-lock:
-    name: Check if package-lock.json is up-to-date
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-
-      - uses: actions/checkout@v2
-
-      - name: Calculate the original hash sum
-        run: echo "original_package_lock_hash_sum=$(sha256sum package-lock.json)" >> $GITHUB_ENV
-
-      - name: Install npm dependencies
-        run: npm install --package-lock-only
-
-      - name: Calculate the new hash sum
-        run: echo "new_package_lock_hash_sum=$(sha256sum package-lock.json)" >> $GITHUB_ENV
-
-      - name: Fail if the old and new hash sums are different
-        if: env.original_package_lock_hash_sum != env.new_package_lock_hash_sum
-        run: |
-          echo "It seems like your package-lock.json file is not up-to-date. Try running 'npm install' and commit the changes."
-          exit 1
-
   lint:
     name: Lint everything
 
@@ -40,6 +13,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
+
+      - name: Check if package-lock.json is up to date
+        run: npx --yes package-lock-utd@1.x.x
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This PR switches from our own package-lock.json check to `package-lock-utd` (https://github.com/MBuchalik/package-lock-utd). See #123. Since the check is kinda like a linting check, I decided to merge it into the `lint` job.

Additionally, I decided to change our GH Actions to run on Node 18 instead of Node 16, so that we use the latest LTS version.