### PR TITLE
Reduce the mouse wheel sensitivity

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/group-details/dependency-graph/graph.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/group-details/dependency-graph/graph.tsx
@@ -84,6 +84,7 @@ export const Graph: React.FC<Props> = (props) => {
           layout={cyLayout}
           style={{ width: '100%', height: '100%' }}
           stylesheet={cyStyleSheets}
+          wheelSensitivity={0.2}
           cy={(cy): void => {
             controller.onRenderGraph(cy);
           }}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,8 @@ import ReactDOM from 'react-dom/client';
 import { App } from './app';
 import './theme/main.scss';
 
+patchConsoleWarn();
+
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
@@ -15,3 +17,25 @@ root.render(
     </CssBaseline>
   </React.StrictMode>,
 );
+
+/**
+ * Silence a warning message printed by Cytoscape.
+ */
+function patchConsoleWarn(): void {
+  const WARNING_TO_SUPPRESS = 'You have set a custom wheel sensitivity.';
+
+  const originalConsoleWarnFn = console.warn;
+
+  console.warn = (...data: unknown[]): void => {
+    if (
+      typeof data[0] === 'string' &&
+      data[0].startsWith(WARNING_TO_SUPPRESS)
+    ) {
+      // `console.warn()` has been called with the message we want to silence? --> Do not print anything to the console.
+      return;
+    }
+
+    // Call the original warning function so that developers can use `console.warn()` like they are used to.
+    originalConsoleWarnFn(...data);
+  };
+}


### PR DESCRIPTION
Closes #116. Since Cytoscape prints a warning when reducing the sensitivity, I decided to monkey-patch `console.warn()` in order to silence the warning.

@georg-schwarz Could you try whether the new settings are ok with your mouse? On my side, zooming now feels pretty "natural", but this could be related to my setup.