### PR TITLE
Hide the group details when there are no Service Docs

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/group-details/group-details.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/group-details/group-details.tsx
@@ -27,7 +27,7 @@ export const GroupDetails: React.FC = () => {
 
   return (
     <React.Fragment>
-      {controller.group !== undefined && (
+      {controller.group !== undefined && !controller.isEmptyGroup && (
         <Box
           sx={{
             overflowX: 'hidden',
@@ -131,6 +131,7 @@ export const GroupDetails: React.FC = () => {
 
 interface Controller {
   group: RegularGroupNode | RootGroupNode | undefined;
+  isEmptyGroup: boolean;
 }
 function useController(): Controller {
   const selectedTreeItem = useSelectedTreeItem();
@@ -144,7 +145,26 @@ function useController(): Controller {
     group = selectedTreeItem;
   }
 
+  const isEmptyGroup = ((): boolean => {
+    if (!group) {
+      return true;
+    }
+    if (group.type === ServiceDocsTreeNodeType.RegularGroup) {
+      // By design, a regular group cannot be empty.
+      return false;
+    }
+
+    if (
+      Object.entries(group.childGroups).length > 0 ||
+      group.services.length > 0
+    ) {
+      return false;
+    }
+    return true;
+  })();
+
   return {
     group: group,
+    isEmptyGroup: isEmptyGroup,
   };
 }


### PR DESCRIPTION
I noticed that when there are no Service Docs (e.g. because the filter is not matching anything), the page looks like this:

![grafik](https://user-images.githubusercontent.com/8061217/216624545-494ec5b0-d7cc-4e69-b0d2-9b75fff89100.png)

So we have a lot of boxes saying "0 foo, 0 bar, ...", and the graph is completely blank.

Certainly, we could add case distinctions in all of the cards that say "there is currently nothing to show". But the much simpler solution is to simply hide the right content completely:

![grafik](https://user-images.githubusercontent.com/8061217/216624818-f0c91961-b98a-4a6e-8516-dd7ea4405e29.png)


Given that we already have the warning message on the left ("No Service Docs found"), I believe/hope this is sufficient for now.