### PR TITLE
Make it possible to filter by Extension Field

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/filter/models.ts
+++ b/frontend/src/components/main-page/service-docs-explorer-page/filter/models.ts
@@ -27,10 +27,23 @@ export interface FilterNotNode {
 
   child: FilterNode;
 }
+
+/**
+ * Users can write "extensions.foo:bar" to ask for extension field "foo" with value "bar".
+ */
+export const EXTENSIONS_KEY_PREFIX = 'extensions.';
+export type ExtensionsKey = `${typeof EXTENSIONS_KEY_PREFIX}${string}`;
+export function isExtensionsKey(key: string): key is ExtensionsKey {
+  if (key.startsWith(EXTENSIONS_KEY_PREFIX)) {
+    return true;
+  }
+  return false;
+}
+
 export interface FilterKeyValueNode {
   type: ExpressionNodeType.KeyValue;
 
-  key: AllowedLiteralNodeKey;
+  key: AllowedLiteralNodeKey | ExtensionsKey;
   value: string;
 }
 

--- a/frontend/src/components/main-page/service-docs-explorer-page/filter/models.ts
+++ b/frontend/src/components/main-page/service-docs-explorer-page/filter/models.ts
@@ -34,10 +34,7 @@ export interface FilterNotNode {
 export const EXTENSIONS_KEY_PREFIX = 'extensions.';
 export type ExtensionsKey = `${typeof EXTENSIONS_KEY_PREFIX}${string}`;
 export function isExtensionsKey(key: string): key is ExtensionsKey {
-  if (key.startsWith(EXTENSIONS_KEY_PREFIX)) {
-    return true;
-  }
-  return false;
+  return key.startsWith(EXTENSIONS_KEY_PREFIX);
 }
 
 export interface FilterKeyValueNode {

--- a/frontend/src/components/main-page/service-docs-explorer-page/filter/parse-query.ts
+++ b/frontend/src/components/main-page/service-docs-explorer-page/filter/parse-query.ts
@@ -19,6 +19,7 @@ import {
   FilterOrNode,
   FilterParseError,
   isAllowedLiteralNodeKey,
+  isExtensionsKey,
 } from './models';
 
 export function parseFilterQuery(
@@ -142,7 +143,8 @@ function transformKeyValueNodeToInternalRepresentation(
   node: SEPKeyValueNode,
 ): Result<FilterKeyValueNode, FilterParseError> {
   const key = node.key.content.toLowerCase();
-  if (!isAllowedLiteralNodeKey(key)) {
+
+  if (!isAllowedLiteralNodeKey(key) && !isExtensionsKey(key)) {
     return {
       success: false,
       error: {

--- a/frontend/src/components/main-page/service-docs-explorer-page/filter/syntax-documentation.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/filter/syntax-documentation.tsx
@@ -48,6 +48,13 @@ export const SyntaxDocumentation: React.FC = () => {
         <li>responsibleTeam</li>
         <li>responsible</li>
       </ul>
+      <Box sx={{ marginY: 3 }}>
+        Additionally, you can filter for <b>Extension Fields</b> using the
+        following syntax:
+        <Example example="extensions.customField:important" />
+        In this example, all Service Docs are matched that have an Extension
+        Field called {`"customField"`} with value {`"important"`}.
+      </Box>
       <Typography variant="h5">Wildcards</Typography>
       <Box>
         You can use wildcards to perform matching against substrings. For


### PR DESCRIPTION
This PR implements the features described in #133: It is now possible to filter by extension fields. 

For instance, to find all Service Docs where there is an extension field called "deployed" that is `true`, use the following query:

```
extensions.deployed:true
```


Two notes:
- As you know, our queries contain `key:value` pairs. Internally, we now distinguish "Literal Keys" and "Extensions Keys" (plural form intended). A Literal Key is what we have used before, like "name" or "group". An Extensions Key is a key in the format "extensions.something". In the internal data structure, we simply store the key as a string. To check whether we have a Literal Key or an Extensions Key, there is a function that basically just checks if the string starts with "extensions." or not.
- It was necessary to extend the filtering mechanism to also allow to filter by numbers and booleans. Originally, we only supported strings.