### PR TITLE
Show Services without a Responsible/Team

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/navigator/common/navigator-list-item-button.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/navigator/common/navigator-list-item-button.tsx
@@ -7,6 +7,17 @@ interface Props {
   isSelected?: boolean;
 
   /**
+   * Sometimes, our list contains a "fallback element".
+   * For instance, let's say we build a list of teams.
+   * And we have entries that do not belong to a team.
+   * Then we want to create a list item like "No team defined".
+   *
+   * In this case, we want to use a slightly different styling compared to regular items,
+   * so that users know that we aren't talking about a team called "No team defined".
+   */
+  isFallbackElement?: boolean;
+
+  /**
    * Spacing that will be added to the left.
    * This is particularly useful to visualize tree structures or the like:
    * Use an indent level of 0 for the root element,
@@ -75,7 +86,16 @@ export const NavigatorListItemButton: React.FC<Props> = (props) => {
       >
         {props.icon}
       </ListItemIcon>
-      <ListItemText primary={props.text} />
+      <ListItemText
+        primary={props.text}
+        sx={{
+          fontStyle: props.isFallbackElement === true ? 'italic' : undefined,
+          color: (theme) =>
+            props.isFallbackElement === true
+              ? theme.palette.grey[500]
+              : undefined,
+        }}
+      />
     </ListItemButton>
   );
 };

--- a/frontend/src/components/main-page/service-docs-explorer-page/navigator/responsibles/responsible-item.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/navigator/responsibles/responsible-item.tsx
@@ -9,15 +9,16 @@ import { ServiceNode } from '../../../service-docs-tree';
 import { NavigatorListItemButton } from '../common/navigator-list-item-button';
 import { ServiceItem } from '../common/service-item';
 
-export interface ResponsibleWithServiceDocs {
-  responsibleName: string;
-  correspondingServiceDocs: ServiceNode[];
-}
-
 interface Props {
-  responsible: ResponsibleWithServiceDocs;
+  /**
+   * The name of the Responsible the {@link serviceDocs} belong to.
+   *
+   * Special case: This value is `undefined` if no Responsible has been defined for the given {@link serviceDocs}.
+   */
+  responsibleName: string | undefined;
+  serviceDocs: ServiceNode[];
 }
-export const SingleResponsible: React.FC<Props> = (props) => {
+export const ResponsibleItem: React.FC<Props> = (props) => {
   const controller = useController(props);
 
   return (
@@ -30,7 +31,8 @@ export const SingleResponsible: React.FC<Props> = (props) => {
             <Icons.ExpandMore />
           )
         }
-        text={props.responsible.responsibleName}
+        text={props.responsibleName ?? 'No Responsible'}
+        isFallbackElement={props.responsibleName === undefined}
         onClick={(): void => controller.toggleIsCollapsed()}
       />
 
@@ -69,13 +71,13 @@ function useController(props: Props): Controller {
   });
 
   const sortedServiceDocs = React.useMemo((): ServiceNode[] => {
-    const result = [...props.responsible.correspondingServiceDocs];
+    const result = [...props.serviceDocs];
     result.sort((a, b) => {
       return a.name.localeCompare(b.name);
     });
 
     return result;
-  }, [props.responsible.correspondingServiceDocs]);
+  }, [props.serviceDocs]);
 
   return {
     state: state,

--- a/frontend/src/components/main-page/service-docs-explorer-page/navigator/responsibles/responsibles.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/navigator/responsibles/responsibles.tsx
@@ -1,12 +1,10 @@
 import { Alert, List } from '@mui/material';
 import React from 'react';
 
+import { ServiceNode } from '../../../service-docs-tree';
 import { useServiceDocsServiceContext } from '../../../services/service-docs-service';
 
-import {
-  ResponsibleWithServiceDocs,
-  SingleResponsible,
-} from './single-responsible';
+import { ResponsibleItem } from './responsible-item';
 
 export const Responsibles: React.FC = () => {
   const controller = useController();
@@ -20,9 +18,10 @@ export const Responsibles: React.FC = () => {
       {controller.responsibles.length > 0 && (
         <List component="div" disablePadding>
           {controller.responsibles.map((singleResponsible) => (
-            <SingleResponsible
-              key={singleResponsible.responsibleName}
-              responsible={singleResponsible}
+            <ResponsibleItem
+              key={singleResponsible.responsibleName ?? 'no-responsible'}
+              responsibleName={singleResponsible.responsibleName}
+              serviceDocs={singleResponsible.correspondingServiceDocs}
             />
           ))}
         </List>
@@ -31,6 +30,14 @@ export const Responsibles: React.FC = () => {
   );
 };
 
+/**
+ * Service Docs grouped by a particular Responsible.
+ */
+interface ResponsibleWithServiceDocs {
+  responsibleName: string | undefined;
+  correspondingServiceDocs: ServiceNode[];
+}
+
 interface Controller {
   responsibles: ResponsibleWithServiceDocs[];
 }
@@ -38,30 +45,15 @@ function useController(): Controller {
   const serviceDocsService = useServiceDocsServiceContext();
 
   const responsibles = React.useMemo((): ResponsibleWithServiceDocs[] => {
-    const responsiblesByName: Record<string, ResponsibleWithServiceDocs> = {};
-
-    for (const singleServiceDoc of serviceDocsService.serviceDocs) {
-      if (!singleServiceDoc.responsibles) {
-        continue;
-      }
-
-      for (const singleResponsible of singleServiceDoc.responsibles) {
-        let mapEntry = responsiblesByName[singleResponsible];
-
-        if (!mapEntry) {
-          mapEntry = {
-            responsibleName: singleResponsible,
-            correspondingServiceDocs: [],
-          };
-          responsiblesByName[singleResponsible] = mapEntry;
-        }
-
-        mapEntry.correspondingServiceDocs.push(singleServiceDoc);
-      }
-    }
-
-    const result = Object.values(responsiblesByName);
+    const result = groupServiceDocsByResponsibles(
+      serviceDocsService.serviceDocs,
+    );
     result.sort((a, b) => {
+      // Move the element that contains the items without a Responsible to the end.
+      if (a.responsibleName === undefined || b.responsibleName === undefined) {
+        return 1;
+      }
+
       return a.responsibleName.localeCompare(b.responsibleName);
     });
 
@@ -71,4 +63,46 @@ function useController(): Controller {
   return {
     responsibles: responsibles,
   };
+}
+
+function groupServiceDocsByResponsibles(
+  serviceDocs: ServiceNode[],
+): ResponsibleWithServiceDocs[] {
+  const responsiblesByName: Record<string, ResponsibleWithServiceDocs> = {};
+  const serviceDocsWithoutResponsible: ServiceNode[] = [];
+
+  for (const singleServiceDoc of serviceDocs) {
+    if (
+      !singleServiceDoc.responsibles ||
+      singleServiceDoc.responsibles.length < 1
+    ) {
+      serviceDocsWithoutResponsible.push(singleServiceDoc);
+      continue;
+    }
+
+    for (const singleResponsible of singleServiceDoc.responsibles) {
+      let mapEntry = responsiblesByName[singleResponsible];
+
+      if (!mapEntry) {
+        mapEntry = {
+          responsibleName: singleResponsible,
+          correspondingServiceDocs: [],
+        };
+        responsiblesByName[singleResponsible] = mapEntry;
+      }
+
+      mapEntry.correspondingServiceDocs.push(singleServiceDoc);
+    }
+  }
+
+  const result = Object.values(responsiblesByName);
+
+  if (serviceDocsWithoutResponsible.length > 0) {
+    result.push({
+      responsibleName: undefined,
+      correspondingServiceDocs: serviceDocsWithoutResponsible,
+    });
+  }
+
+  return result;
 }

--- a/frontend/src/components/main-page/service-docs-explorer-page/navigator/teams/team-item.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/navigator/teams/team-item.tsx
@@ -9,15 +9,16 @@ import { ServiceNode } from '../../../service-docs-tree';
 import { NavigatorListItemButton } from '../common/navigator-list-item-button';
 import { ServiceItem } from '../common/service-item';
 
-export interface TeamWithServiceDocs {
-  teamName: string;
-  correspondingServiceDocs: ServiceNode[];
-}
-
 interface Props {
-  team: TeamWithServiceDocs;
+  /**
+   * The name of the Team the {@link serviceDocs} belong to.
+   *
+   * Special case: This value is `undefined` if no Team has been defined for the given {@link serviceDocs}.
+   */
+  teamName: string | undefined;
+  serviceDocs: ServiceNode[];
 }
-export const SingleTeam: React.FC<Props> = (props) => {
+export const TeamItem: React.FC<Props> = (props) => {
   const controller = useController(props);
 
   return (
@@ -30,7 +31,8 @@ export const SingleTeam: React.FC<Props> = (props) => {
             <Icons.ExpandMore />
           )
         }
-        text={props.team.teamName}
+        text={props.teamName ?? 'No Team'}
+        isFallbackElement={props.teamName === undefined}
         onClick={(): void => controller.toggleIsCollapsed()}
       />
 
@@ -69,13 +71,13 @@ function useController(props: Props): Controller {
   });
 
   const sortedServiceDocs = React.useMemo((): ServiceNode[] => {
-    const result = [...props.team.correspondingServiceDocs];
+    const result = [...props.serviceDocs];
     result.sort((a, b) => {
       return a.name.localeCompare(b.name);
     });
 
     return result;
-  }, [props.team.correspondingServiceDocs]);
+  }, [props.serviceDocs]);
 
   return {
     state: state,


### PR DESCRIPTION
Closes #132: When viewing the Responsibles or the Team list, we originally did not show Service Docs that do not have a Responsible/Team. Now, there is a special item that is always shown at the end of the list. This item contains all Services that do not have a Responsible/Team.

# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/218431377-5ea35f20-9dd8-415e-ae4a-7676baad1bc6.png)
![grafik](https://user-images.githubusercontent.com/8061217/218431437-505b2d27-c034-4d02-94cf-ee56b02f843b.png)
![grafik](https://user-images.githubusercontent.com/8061217/218431478-8306d2e3-d683-44c3-88cb-daa26b95bb85.png)
![grafik](https://user-images.githubusercontent.com/8061217/218431526-630ec6ef-c4d3-40d7-9264-f2788a76386f.png)
