### PR TITLE
Add a plain list view for Service Docs

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/navigator/navigator.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/navigator/navigator.tsx
@@ -7,10 +7,12 @@ import { merge } from '../../../../utils/merge';
 
 import { GroupsTree } from './groups-tree';
 import { Responsibles } from './responsibles';
+import { ServicesList } from './services-list';
 import { Teams } from './teams';
 
 enum NavigatorView {
   GroupsTree,
+  ServicesList,
   Responsibles,
   Teams,
 }
@@ -46,6 +48,16 @@ export const Navigator: React.FC = () => {
           }
         />
         <TabButton
+          icon={<Icons.ViewList fontSize="inherit" />}
+          title="Services List"
+          isActive={
+            controller.state.selectedView === NavigatorView.ServicesList
+          }
+          onClick={(): void =>
+            controller.setSelectedView(NavigatorView.ServicesList)
+          }
+        />
+        <TabButton
           icon={<Icons.Person fontSize="inherit" />}
           title="Responsibles"
           isActive={
@@ -66,6 +78,9 @@ export const Navigator: React.FC = () => {
       <Box sx={{ flexGrow: 1, overflow: 'auto' }}>
         {controller.state.selectedView === NavigatorView.GroupsTree && (
           <GroupsTree />
+        )}
+        {controller.state.selectedView === NavigatorView.ServicesList && (
+          <ServicesList />
         )}
         {controller.state.selectedView === NavigatorView.Responsibles && (
           <Responsibles />

--- a/frontend/src/components/main-page/service-docs-explorer-page/navigator/services-list.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/navigator/services-list.tsx
@@ -1,0 +1,45 @@
+import { List } from '@mui/material';
+import React from 'react';
+
+import { ServiceNode } from '../../service-docs-tree';
+import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+
+import { ServiceItem } from './common/service-item';
+
+export const ServicesList: React.FC = () => {
+  const controller = useController();
+
+  return (
+    <List component="div" disablePadding>
+      {controller.sortedServiceDocs.map((serviceDoc) => (
+        <ServiceItem
+          key={serviceDoc.name}
+          service={serviceDoc}
+          indent={0}
+          autoScrollIntoView
+        />
+      ))}
+    </List>
+  );
+};
+
+interface Controller {
+  sortedServiceDocs: ServiceNode[];
+}
+function useController(): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const sortedServiceDocs = React.useMemo((): ServiceNode[] => {
+    const result = [...serviceDocsService.serviceDocs];
+
+    result.sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
+
+    return result;
+  }, [serviceDocsService.serviceDocs]);
+
+  return {
+    sortedServiceDocs: sortedServiceDocs,
+  };
+}


### PR DESCRIPTION
Closes #147

This PR adds a plain list view for Service Docs as described in #147.

# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/218714275-33d7c4b4-0983-4bd4-a244-d5501b39754a.png)
![grafik](https://user-images.githubusercontent.com/8061217/218714329-5c8496b5-98a4-4a1b-8eed-7d197d192268.png)


![grafik](https://user-images.githubusercontent.com/8061217/218714189-a26eb9f4-42d2-4882-8624-99de7de06e86.png)
