### PR TITLE
Implement a simple search dialog

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/filter/filter-dialog.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/filter/filter-dialog.tsx
@@ -32,7 +32,7 @@ export const FilterDialog: React.FC<Props> = (props) => {
 
   return (
     <Dialog maxWidth={false} open onClose={(): void => props.close()}>
-      <DialogTitle>Filter</DialogTitle>
+      <DialogTitle>Filter Services</DialogTitle>
 
       <DialogContent sx={{ width: '900px', maxWidth: '100%' }} dividers>
         {controller.state.filterParseError && (

--- a/frontend/src/components/main-page/service-docs-explorer-page/search/index.ts
+++ b/frontend/src/components/main-page/service-docs-explorer-page/search/index.ts
@@ -1,0 +1,1 @@
+export { SearchDialog } from './search-dialog';

--- a/frontend/src/components/main-page/service-docs-explorer-page/search/search-dialog.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/search/search-dialog.tsx
@@ -1,0 +1,192 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItemButton,
+  ListItemText,
+  TextField,
+} from '@mui/material';
+import React from 'react';
+import { generatePath, useNavigate } from 'react-router-dom';
+
+import { SERVICE_DOCS_EXPLORER_ROUTES_ABS } from '../../../../routes';
+import { merge } from '../../../../utils/merge';
+import { ServiceNode } from '../../service-docs-tree';
+import { useServiceDocsServiceContext } from '../../services/service-docs-service';
+
+interface Props {
+  close: () => void;
+}
+export const SearchDialog: React.FC<Props> = (props) => {
+  const controller = useController();
+
+  return (
+    <Dialog
+      maxWidth={false}
+      /* The following line moves the dialog to the top. */
+      PaperProps={{ sx: { alignSelf: 'start' } }}
+      open
+      onClose={(): void => props.close()}
+    >
+      <DialogTitle>Find Service</DialogTitle>
+
+      <DialogContent sx={{ width: '700px', maxWidth: '100%' }} dividers>
+        <Box>
+          <TextField
+            sx={{ width: '100%' }}
+            label="Service Name"
+            value={controller.state.searchQuery}
+            onChange={(e): void => controller.setSearchQuery(e.target.value)}
+          />
+        </Box>
+
+        {controller.searchResults.length < 1 && (
+          <Alert severity="info" sx={{ marginTop: 2 }}>
+            No matching results
+          </Alert>
+        )}
+
+        {controller.searchResults.length > 0 && (
+          <Box sx={{ maxHeight: '300px', overflowY: 'scroll' }}>
+            <List component="div">
+              {controller.searchResults.map((searchResultItem) => (
+                <ListItemButton
+                  key={searchResultItem.serviceDoc.name}
+                  onClick={(): void => {
+                    controller.navigateToService(searchResultItem.serviceDoc);
+                    props.close();
+                  }}
+                >
+                  <ListItemText>
+                    {searchResultItem.highlightNameRange ? (
+                      <HighlightTextAtRange
+                        text={searchResultItem.serviceDoc.name}
+                        range={searchResultItem.highlightNameRange}
+                      />
+                    ) : (
+                      <span>{searchResultItem.serviceDoc.name}</span>
+                    )}
+                  </ListItemText>
+                </ListItemButton>
+              ))}
+            </List>
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={(): void => props.close()}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+interface SearchResultItem {
+  serviceDoc: ServiceNode;
+
+  /**
+   * The range in the name of the Service Doc to highlight.
+   *
+   * The end of the range is exclusive: `[3,5]` highlights the characters at indexes 3 to 4.
+   */
+  highlightNameRange?: [number, number];
+}
+interface State {
+  searchQuery: string;
+}
+interface Controller {
+  state: State;
+
+  searchResults: SearchResultItem[];
+
+  setSearchQuery: (query: string) => void;
+  navigateToService: (service: ServiceNode) => void;
+}
+function useController(): Controller {
+  const navigate = useNavigate();
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const [state, setState] = React.useState<State>({
+    searchQuery: '',
+  });
+
+  const searchResult = React.useMemo((): SearchResultItem[] => {
+    const result: SearchResultItem[] = [];
+
+    const preparedSearchQuery = state.searchQuery.trim().toLowerCase();
+
+    for (const singleServiceDoc of serviceDocsService.serviceDocs) {
+      // The search query is empty? Then we simply want to show all services.
+      if (preparedSearchQuery === '') {
+        result.push({ serviceDoc: singleServiceDoc });
+        continue;
+      }
+
+      const index = singleServiceDoc.name
+        .toLowerCase()
+        .indexOf(preparedSearchQuery);
+      if (index < 0) {
+        continue;
+      }
+
+      result.push({
+        serviceDoc: singleServiceDoc,
+        highlightNameRange: [index, index + state.searchQuery.length],
+      });
+    }
+
+    result.sort((a, b) => {
+      return a.serviceDoc.name.localeCompare(b.serviceDoc.name);
+    });
+
+    return result;
+  }, [serviceDocsService.serviceDocs, state.searchQuery]);
+
+  return {
+    state: state,
+
+    searchResults: searchResult,
+
+    setSearchQuery: (query): void => {
+      setState((state) => merge(state, { searchQuery: query }));
+    },
+    navigateToService: (service): void => {
+      navigate(
+        generatePath(SERVICE_DOCS_EXPLORER_ROUTES_ABS.service, {
+          service: service.name,
+        }),
+      );
+    },
+  };
+}
+
+interface HighlightTextAtRangeProps {
+  text: string;
+
+  /**
+   * The range in the {@link text} to highlight.
+   *
+   * The end of the range is exclusive: `[3,5]` highlights the characters at indexes 3 to 4.
+   */
+  range: [number, number];
+}
+const HighlightTextAtRange: React.FC<HighlightTextAtRangeProps> = (props) => {
+  const textBeforeRange = props.text.slice(0, props.range[0]);
+  const textToHighlight = props.text.slice(props.range[0], props.range[1]);
+  const textAfterRange = props.text.slice(props.range[1]);
+
+  return (
+    <span>
+      <span>{textBeforeRange}</span>
+      <span style={{ textDecoration: 'underline', fontWeight: 700 }}>
+        {textToHighlight}
+      </span>
+      <span>{textAfterRange}</span>
+    </span>
+  );
+};

--- a/frontend/src/components/main-page/service-docs-explorer-page/service-docs-explorer-page.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/service-docs-explorer-page.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Divider, IconButton } from '@mui/material';
+import { Alert, Box, Divider, IconButton, Tooltip } from '@mui/material';
 import { GetServiceDocResponse } from 'msadoc-client';
 import React from 'react';
 
@@ -13,6 +13,7 @@ import {
 import { FilterDialog, FilterNode, applyFilter } from './filter';
 import { Navigator } from './navigator';
 import { ServiceDocsExplorerPageRouter } from './router';
+import { SearchDialog } from './search';
 
 export const ServiceDocsExplorerPage: React.FC = () => {
   const controller = useController();
@@ -43,11 +44,21 @@ export const ServiceDocsExplorerPage: React.FC = () => {
             }}
           >
             <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <IconButton
-                onClick={(): void => controller.setShowFilterDialog(true)}
-              >
-                <Icons.FilterAlt />
-              </IconButton>
+              <Tooltip title="Find Service">
+                <IconButton
+                  onClick={(): void => controller.setShowSearchDialog(true)}
+                >
+                  <Icons.Search />
+                </IconButton>
+              </Tooltip>
+
+              <Tooltip title="Filter Services">
+                <IconButton
+                  onClick={(): void => controller.setShowFilterDialog(true)}
+                >
+                  <Icons.FilterAlt />
+                </IconButton>
+              </Tooltip>
             </Box>
 
             <Divider />
@@ -74,6 +85,12 @@ export const ServiceDocsExplorerPage: React.FC = () => {
             />
           </Box>
         </Box>
+
+        {controller.state.showSearchDialog && (
+          <SearchDialog
+            close={(): void => controller.setShowSearchDialog(false)}
+          />
+        )}
       </ServiceDocsServiceContextProvider>
 
       {controller.state.showFilterDialog && (
@@ -98,6 +115,7 @@ interface State {
   filter: FilterNode | undefined;
   rawFilterQuery: string | undefined;
 
+  showSearchDialog: boolean;
   showFilterDialog: boolean;
 }
 interface Controller {
@@ -110,6 +128,7 @@ interface Controller {
 
   rawFilteredServiceDocs: GetServiceDocResponse[];
 
+  setShowSearchDialog: (show: boolean) => void;
   setShowFilterDialog: (show: boolean) => void;
   applyFilter: (filter: FilterNode, rawFilterQuery: string) => void;
   removeFilter: () => void;
@@ -120,6 +139,7 @@ function useController(): Controller {
   const [state, setState] = React.useState<State>({
     filter: undefined,
     rawFilterQuery: undefined,
+    showSearchDialog: false,
     showFilterDialog: false,
   });
 
@@ -156,6 +176,9 @@ function useController(): Controller {
 
     rawFilteredServiceDocs: rawFilteredServiceDocs,
 
+    setShowSearchDialog: (show): void => {
+      setState((state) => merge(state, { showSearchDialog: show }));
+    },
     setShowFilterDialog: (show): void => {
       setState((state) => merge(state, { showFilterDialog: show }));
     },


### PR DESCRIPTION
This PR implements a simple search dialog as described in #154.

Two notes:
- The search is affected by the Filter. So if the user has defined a filter, then the list of services shown in the search only includes those matched by the filter.
- At the moment, we perform simple substring matching. In the future, we could think about adding fuzzy searching capabilities using a library like [FuseJS](https://fusejs.io/).

# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/220336119-f64a158c-74f2-4949-839a-300e7502cec0.png)
![grafik](https://user-images.githubusercontent.com/8061217/220336147-35982742-ce40-4e77-9e65-2a652856b3ee.png)
![grafik](https://user-images.githubusercontent.com/8061217/220336174-29a178cc-2b50-4090-af2d-c6cbec5988a2.png)
![grafik](https://user-images.githubusercontent.com/8061217/220336227-8020b5fe-3431-4bbf-92e6-1bd89a6d97ae.png)
