### PR TITLE
Make sure the filter takes substring positions into account

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/filter/apply-filter.ts
+++ b/frontend/src/components/main-page/service-docs-explorer-page/filter/apply-filter.ts
@@ -187,6 +187,8 @@ function isStringMatching(theString: string, theQuery: string): boolean {
   // There is one special case: We want to allow wildcards with the "*" character. So: "un-escape" this character and replace it with a proper Regex wildcard.
   preparedQuery = preparedQuery.replaceAll('\\*', '.*');
 
+  preparedQuery = `^${preparedQuery}$`;
+
   const regex = new RegExp(preparedQuery, 'i');
   return regex.test(theString);
 }


### PR DESCRIPTION
At the moment, when entering `name:serv` into the filer, Services like "FooService" are also found. This is because the Regex we build does not make sure the entire string is checked (i.e. the Regex does not start with `^` and end with `$`). This PR fixes this issue.