### PR TITLE
Show a Popover menu when clicking on an edge

### DIFF
--- a/frontend/src/components/main-page/service-docs-explorer-page/group-details/dependency-graph/edge-details-popover.tsx
+++ b/frontend/src/components/main-page/service-docs-explorer-page/group-details/dependency-graph/edge-details-popover.tsx
@@ -1,0 +1,174 @@
+import { Divider, IconButton, Popover, Tooltip } from '@mui/material';
+import { Box } from '@mui/system';
+import React from 'react';
+
+import { Icons } from '../../../../../icons';
+import {
+  RegularGroupNode,
+  ServiceDocsTreeNodeType,
+  ServiceNode,
+  getGroupByIdentifier,
+} from '../../../service-docs-tree';
+import {
+  ServiceDocsService,
+  useServiceDocsServiceContext,
+} from '../../../services/service-docs-service';
+
+import {
+  GROUP_PREFIX,
+  MyEdgeData,
+  NodeIdentifier,
+  SERVICE_PREFIX,
+} from './cytoscape-builder';
+
+interface Props {
+  edge: MyEdgeData;
+  /**
+   * The mouse event (e.g. click event) that triggered this Popover.
+   */
+  event: MouseEvent;
+
+  close: () => void;
+}
+export const EdgeDetailsPopover: React.FC<Props> = (props) => {
+  const controller = useController(props);
+
+  return (
+    <React.Fragment>
+      {controller.sourceAndTargetNode && (
+        <Popover
+          anchorReference="anchorPosition"
+          anchorPosition={{
+            top: props.event.clientY,
+            left: props.event.clientX,
+          }}
+          open
+          onClose={(): void => props.close()}
+        >
+          <Box sx={{ display: 'flex', justifyContent: 'end' }}>
+            <Box>
+              <Tooltip title="Close">
+                <IconButton onClick={(): void => props.close()}>
+                  <Icons.Close />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          </Box>
+
+          <Divider />
+
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              paddingX: 4,
+              paddingY: 2,
+            }}
+          >
+            <Box>
+              {controller.sourceAndTargetNode.sourceNode.type ===
+              ServiceDocsTreeNodeType.RegularGroup
+                ? controller.sourceAndTargetNode.sourceNode.identifier
+                : controller.sourceAndTargetNode.sourceNode.name}
+            </Box>
+
+            <Box>
+              {/* By default, the icon does not get perfectly centered. This can be fixed using display:block. */}
+              <Icons.ArrowForward sx={{ display: 'block' }} />
+            </Box>
+
+            <Box>
+              {controller.sourceAndTargetNode.targetNode.type ===
+              ServiceDocsTreeNodeType.RegularGroup
+                ? controller.sourceAndTargetNode.targetNode.identifier
+                : controller.sourceAndTargetNode.targetNode.name}
+            </Box>
+          </Box>
+        </Popover>
+      )}
+    </React.Fragment>
+  );
+};
+
+interface SourceAndTargetNode {
+  sourceNode: RegularGroupNode | ServiceNode;
+  targetNode: RegularGroupNode | ServiceNode;
+}
+
+interface Controller {
+  sourceAndTargetNode: SourceAndTargetNode | undefined;
+}
+function useController(props: Props): Controller {
+  const serviceDocsService = useServiceDocsServiceContext();
+
+  const sourceAndTargetNode = React.useMemo(():
+    | SourceAndTargetNode
+    | undefined => {
+    const parsedSourceIdentifier = parseNodeIdentifier(props.edge.source);
+    const parsedTargetIdentifier = parseNodeIdentifier(props.edge.target);
+
+    const sourceNode = findNode(parsedSourceIdentifier, serviceDocsService);
+    const targetNode = findNode(parsedTargetIdentifier, serviceDocsService);
+
+    if (!sourceNode || !targetNode) {
+      return undefined;
+    }
+
+    return {
+      sourceNode: sourceNode,
+      targetNode: targetNode,
+    };
+  }, [props.edge.source, props.edge.target, serviceDocsService]);
+
+  return {
+    sourceAndTargetNode: sourceAndTargetNode,
+  };
+}
+
+interface ParsedNodeIdentifier {
+  type: 'service' | 'group';
+  actualIdentifier: string;
+}
+function parseNodeIdentifier(
+  nodeIdentifier: NodeIdentifier,
+): ParsedNodeIdentifier {
+  if (nodeIdentifier.startsWith(SERVICE_PREFIX)) {
+    // This only replaces the first occurrence of the string.
+    const actualIdentifier = nodeIdentifier.replace(SERVICE_PREFIX, '');
+
+    return {
+      type: 'service',
+      actualIdentifier: actualIdentifier,
+    };
+  }
+
+  if (nodeIdentifier.startsWith(GROUP_PREFIX)) {
+    // This only replaces the first occurrence of the string.
+    const actualIdentifier = nodeIdentifier.replace(GROUP_PREFIX, '');
+
+    return {
+      type: 'group',
+      actualIdentifier: actualIdentifier,
+    };
+  }
+
+  throw Error(
+    `Tried to parse an invalid identifier. This should not happen. The identifier: "${nodeIdentifier}"`,
+  );
+}
+
+function findNode(
+  nodeIdentifier: ParsedNodeIdentifier,
+  serviceDocsService: ServiceDocsService,
+): RegularGroupNode | ServiceNode | undefined {
+  if (nodeIdentifier.type === 'service') {
+    return serviceDocsService.serviceDocs.find(
+      (item) => item.name === nodeIdentifier.actualIdentifier,
+    );
+  }
+  return getGroupByIdentifier(
+    nodeIdentifier.actualIdentifier,
+    serviceDocsService.groupsTree,
+  );
+}


### PR DESCRIPTION
When clicking on an edge in the graph, a Popover is now shown. This is roughly as described in #106.

The Popover stays open until the user clicks outside of it. It can also be closed using a "x" button.

At the moment, the Popover only shows the name of the source and target of the edge. In a future PR, we could add additional information. 

I was a bit hesitant when it comes to adding additional information, because I did not know how to deal with cases where there is more than just one Event (or API) for one given pair of source/target nodes. I think the CytoscapeBuilder simply creates multiple edges for this. But they will probably just be rendered on top of each other. So we might need to do some pre-processing here in order to determine which Events/APIs are actually connecting the two nodes.

# Screenshots

![grafik](https://user-images.githubusercontent.com/8061217/224694044-c41da3a4-e1cb-4022-b9c3-987b3dcf1b62.png)
![grafik](https://user-images.githubusercontent.com/8061217/224694084-e62e2bbf-1c27-4718-8e05-75610f6ee972.png)
