### PR TITLE
Remove unnecessary "version" fields

### DIFF
--- a/client-generated/package.json
+++ b/client-generated/package.json
@@ -1,6 +1,5 @@
 {
   "name": "msadoc-client",
-  "version": "1.0",
   "description": "OpenAPI client for msadoc-server",
   "author": "OpenAPI-Generator",
   "private": true,

--- a/client-generator/package.json
+++ b/client-generator/package.json
@@ -1,6 +1,5 @@
 {
   "name": "client-generator",
-  "version": "1.0.0",
   "license": "Apache 2.0",
   "description": "This project generates client code from the `MSAdoc server` project using [@openapitools/openapi-generator-cli](https://github.com/OpenAPITools/openapi-generator-cli) under the hood.",
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "msadoc-frontend",
-  "version": "0.0.1",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "msadoc",
-      "version": "0.0.1",
       "license": "Apache-2.0",
       "workspaces": [
         "client-generated",
@@ -158,11 +157,9 @@
     },
     "client-generated": {
       "name": "msadoc-client",
-      "version": "1.0",
       "hasInstallScript": true
     },
     "client-generator": {
-      "version": "1.0.0",
       "license": "Apache 2.0",
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.5.2"
@@ -170,7 +167,6 @@
     },
     "frontend": {
       "name": "msadoc-frontend",
-      "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.5",
@@ -13454,7 +13450,6 @@
     },
     "server": {
       "name": "msadoc-server",
-      "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@nestjs/common": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "msadoc",
-  "version": "0.0.1",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": [

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "msadoc-server",
-  "version": "0.0.1",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
This PR closes #162 by removing unnecessary "version" fields from all `package.json` files (except for the CLI).